### PR TITLE
Allow cluster to start if we have quorum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,10 @@ DOCKER_TAG=1.0.20170421
 all: images
 
 gofmt:
-	gofmt -w -s cmd/
-	gofmt -w -s pkg/
+	gofmt -w -s cmd/ pkg/
 
 goimports:
-	goimports -w cmd/
-	goimports -w pkg/
+	goimports -w cmd/ pkg/ test/
 
 push: images
 	docker push ${DOCKER_REGISTRY}/etcd-manager:${DOCKER_TAG}

--- a/pkg/contextutil/poll.go
+++ b/pkg/contextutil/poll.go
@@ -2,8 +2,9 @@ package contextutil
 
 import (
 	"context"
-	"github.com/golang/glog"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 func Sleep(ctx context.Context, duration time.Duration) error {

--- a/pkg/etcdclient/v2.go
+++ b/pkg/etcdclient/v2.go
@@ -12,9 +12,15 @@ import (
 	"github.com/golang/glog"
 )
 
+type Client interface {
+	ListMembers(ctx context.Context) ([]*EtcdProcessMember, error)
+}
+
 type etcdClient struct {
 	ClientURL string
 }
+
+var _ Client = &etcdClient{}
 
 type EtcdProcessMember struct {
 	Id         string   `json:"id,omitempty"`
@@ -49,7 +55,7 @@ type etcdProcessMemberList struct {
 	Members []*EtcdProcessMember `json:"members"`
 }
 
-func NewClient(clientURL string) *etcdClient {
+func NewClient(clientURL string) Client {
 	return &etcdClient{
 		ClientURL: clientURL,
 	}

--- a/pkg/privateapi/peers.go
+++ b/pkg/privateapi/peers.go
@@ -13,6 +13,9 @@ import (
 
 const HealthyTimeout = time.Minute
 
+// defaultDiscoveryPollInterval is the default value of Server::DiscoveryPollInterval
+const defaultDiscoveryPollInterval = time.Minute
+
 type PeerId string
 
 type Peers interface {
@@ -37,10 +40,13 @@ type peer struct {
 	lastPingTime time.Time
 
 	conn *grpc.ClientConn
+
+	// DiscoveryPollInterval is the frequency with which we perform peer discovery
+	DiscoveryPollInterval time.Duration
 }
 
 func (s *Server) runDiscovery(ctx context.Context) {
-	contextutil.Forever(ctx, time.Minute, func() {
+	contextutil.Forever(ctx, s.DiscoveryPollInterval, func() {
 		err := s.runDiscoveryOnce()
 		if err != nil {
 			glog.Warningf("unexpected error from peer intercommunications: %v", err)

--- a/pkg/privateapi/server.go
+++ b/pkg/privateapi/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
@@ -19,6 +20,9 @@ type Server struct {
 	mutex      sync.Mutex
 	peers      map[PeerId]*peer
 	leadership *leadership
+
+	// DiscoveryPollInterval is the interval with which we request peers from discovery
+	DiscoveryPollInterval time.Duration
 }
 
 func NewServer(myInfo PeerInfo, discovery Discovery) (*Server, error) {
@@ -26,6 +30,7 @@ func NewServer(myInfo PeerInfo, discovery Discovery) (*Server, error) {
 		discovery: discovery,
 		myInfo:    myInfo,
 		peers:     make(map[PeerId]*peer),
+		DiscoveryPollInterval: defaultDiscoveryPollInterval,
 	}
 
 	var opts []grpc.ServerOption

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -247,10 +247,11 @@ func TestClusterWithOneMember(t *testing.T) {
 func waitForListMembers(client etcdclient.Client, timeout time.Duration) {
 	endAt := time.Now().Add(timeout)
 	for {
-		_, err := client.ListMembers(context.Background())
+		members, err := client.ListMembers(context.Background())
 		if err == nil {
 			return
 		}
+		glog.Infof("Got members from %s: (%v, %v)", client, members, err)
 		if time.Now().After(endAt) {
 			break
 		}
@@ -289,50 +290,50 @@ func TestClusterWithThreeMembers(t *testing.T) {
 	h.Close()
 }
 
-//func TestClusterExpansion(t *testing.T) {
-//	ctx := context.TODO()
-//	ctx, cancel := context.WithTimeout(ctx, time.Second*60)
-//
-//	defer cancel()
-//
-//	h := NewTestHarness(t, ctx)
-//	h.MemberCount = 3
-//	defer h.Close()
-//
-//	n1 := h.NewNode("127.0.0.1")
-//	go n1.Run()
-//	n2 := h.NewNode("127.0.0.2")
-//	go n2.Run()
-//
-//	client1 := etcdclient.NewClient("http://127.0.0.1:4001")
-//	waitForListMembers(client1, 20*time.Second)
-//	members1, err := client1.ListMembers(ctx)
-//	if err != nil {
-//		t.Errorf("error doing etcd ListMembers: %v", err)
-//	} else if len(members1) != 2 {
-//		t.Errorf("members was not as expected: %v", err)
-//	}
-//
-//	client2 := etcdclient.NewClient("http://127.0.0.2:4002")
-//	members2, err := client2.ListMembers(ctx)
-//	if err != nil {
-//		t.Errorf("error doing etcd ListMembers: %v", err)
-//	} else if len(members2) != 2 {
-//		t.Errorf("members was not as expected: %v", err)
-//	}
-//
-//	n3 := h.NewNode("127.0.0.3")
-//	go n3.Run()
-//
-//	client3 := etcdclient.NewClient("http://127.0.0.3:4001")
-//	waitForListMembers(client3, 30*time.Second)
-//	members3, err := client3.ListMembers(ctx)
-//	if err != nil {
-//		t.Errorf("error doing etcd ListMembers: %v", err)
-//	} else if len(members3) != 3 {
-//		t.Errorf("members was not as expected: %v", err)
-//	}
-//
-//	cancel()
-//	h.Close()
-//}
+func TestClusterExpansion(t *testing.T) {
+	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*60)
+
+	defer cancel()
+
+	h := NewTestHarness(t, ctx)
+	h.MemberCount = 3
+	defer h.Close()
+
+	n1 := h.NewNode("127.0.0.1")
+	go n1.Run()
+	n2 := h.NewNode("127.0.0.2")
+	go n2.Run()
+
+	client1 := etcdclient.NewClient("http://127.0.0.1:4001")
+	waitForListMembers(client1, 20*time.Second)
+	members1, err := client1.ListMembers(ctx)
+	if err != nil {
+		t.Errorf("error doing etcd ListMembers: %v", err)
+	} else if len(members1) != 2 {
+		t.Errorf("members was not as expected: %v", err)
+	}
+
+	client2 := etcdclient.NewClient("http://127.0.0.2:4001")
+	members2, err := client2.ListMembers(ctx)
+	if err != nil {
+		t.Errorf("error doing etcd ListMembers: %v", err)
+	} else if len(members2) != 2 {
+		t.Errorf("members was not as expected: %v", err)
+	}
+
+	n3 := h.NewNode("127.0.0.3")
+	go n3.Run()
+
+	client3 := etcdclient.NewClient("http://127.0.0.3:4001")
+	waitForListMembers(client3, 30*time.Second)
+	members3, err := client3.ListMembers(ctx)
+	if err != nil {
+		t.Errorf("error doing etcd ListMembers: %v", err)
+	} else if len(members3) != 3 {
+		t.Errorf("members was not as expected: %v", err)
+	}
+
+	cancel()
+	h.Close()
+}

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -1,23 +1,24 @@
 package integration
 
 import (
-	"kope.io/etcd-manager/pkg/backup"
-	"github.com/golang/glog"
-	"kope.io/etcd-manager/pkg/controller"
-	"kope.io/etcd-manager/pkg/privateapi"
-	"io/ioutil"
-	"testing"
-	"path/filepath"
-	"path"
-	"fmt"
-	"kope.io/etcd-manager/pkg/etcd"
-	"os"
-	apis_etcd "kope.io/etcd-manager/pkg/apis/etcd"
-	"kope.io/etcd-manager/pkg/etcdclient"
 	"context"
 	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
 	"time"
+
+	"github.com/golang/glog"
+	apis_etcd "kope.io/etcd-manager/pkg/apis/etcd"
 	protoetcd "kope.io/etcd-manager/pkg/apis/etcd"
+	"kope.io/etcd-manager/pkg/backup"
+	"kope.io/etcd-manager/pkg/controller"
+	"kope.io/etcd-manager/pkg/etcd"
+	"kope.io/etcd-manager/pkg/etcdclient"
+	"kope.io/etcd-manager/pkg/privateapi"
 )
 
 func init() {
@@ -67,7 +68,6 @@ func NewTestHarness(t *testing.T, ctx context.Context) *TestHarness {
 func (h *TestHarness) Close() {
 	t := h.T
 
-
 	for k, node := range h.Nodes {
 		glog.Infof("Terminating node %q", k)
 		if err := node.Close(); err != nil {
@@ -87,7 +87,7 @@ type TestHarnessNode struct {
 	Address     string
 	NodeDir     string
 
-	etcdServer *etcd.EtcdServer
+	etcdServer     *etcd.EtcdServer
 	etcdController *controller.EtcdController
 }
 
@@ -179,7 +179,7 @@ func (h *TestHarnessNode) Run() {
 	}
 
 	etcdServer := etcd.NewEtcdServer(h.NodeDir, h.TestHarness.ClusterName, me, peerServer)
-h.etcdServer = etcdServer
+	h.etcdServer = etcdServer
 	go etcdServer.Run(ctx)
 
 	initState := &protoetcd.ClusterSpec{
@@ -200,7 +200,6 @@ h.etcdServer = etcdServer
 	}
 }
 
-
 func (h *TestHarnessNode) Close() error {
 	if h.etcdServer != nil {
 		_, err := h.etcdServer.StopEtcdProcess()
@@ -210,7 +209,6 @@ func (h *TestHarnessNode) Close() error {
 	}
 	return nil
 }
-
 
 func TestClusterWithOneMember(t *testing.T) {
 	ctx := context.TODO()


### PR DESCRIPTION
We previously waited for all the nodes, but we can instead just wait for
enough nodes that the quorum is the same size.  This means we can start
with 2/3 nodes or 4/5 nodes.

This isn't safe in general, because etcd doesn't have a strong notion of
a quorum, configurable separately from the nodes themselves.