### PR TITLE
Experimental locking implementation

### DIFF
--- a/cmd/etcd-manager/BUILD.bazel
+++ b/cmd/etcd-manager/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/backup:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/etcd:go_default_library",
+        "//pkg/locking:go_default_library",
         "//pkg/privateapi:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -28,6 +28,7 @@ import (
 	"kope.io/etcd-manager/pkg/backup"
 	"kope.io/etcd-manager/pkg/controller"
 	"kope.io/etcd-manager/pkg/etcd"
+	"kope.io/etcd-manager/pkg/locking"
 	"kope.io/etcd-manager/pkg/privateapi"
 )
 
@@ -127,7 +128,9 @@ func main() {
 		MemberCount: int32(memberCount),
 	}
 	initialClusterState := controller.StaticInitialClusterSpecProvider(spec)
-	c, err := controller.NewEtcdController(backupStore, clusterName, peerServer, initialClusterState)
+
+	var leaderLock locking.Lock
+	c, err := controller.NewEtcdController(leaderLock, backupStore, clusterName, peerServer, initialClusterState)
 	if err != nil {
 		glog.Fatalf("error building etcd controller: %v", err)
 	}

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/backup:go_default_library",
         "//pkg/contextutil:go_default_library",
         "//pkg/etcdclient:go_default_library",
+        "//pkg/locking:go_default_library",
         "//pkg/privateapi:go_default_library",
         "//vendor/github.com/coreos/etcd/client:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/pkg/locking/BUILD.bazel
+++ b/pkg/locking/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "flock.go",
+        "fs.go",
+        "info.go",
+        "interfaces.go",
+    ],
+    importpath = "kope.io/etcd-manager/pkg/locking",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "lock_test.go",
+    ],
+    importpath = "kope.io/etcd-manager/pkg/locking",
+    library = ":go_default_library",
+)

--- a/pkg/locking/flock.go
+++ b/pkg/locking/flock.go
@@ -1,0 +1,84 @@
+package locking
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/golang/glog"
+)
+
+type FSFlockLock struct {
+	p string
+}
+
+var _ Lock = &FSFlockLock{}
+
+type FSFlockLockGuard struct {
+	p    string
+	file *os.File
+}
+
+var _ LockGuard = &FSFlockLockGuard{}
+
+func NewFSFlockLock(p string) (*FSFlockLock, error) {
+	return &FSFlockLock{
+		p: p,
+	}, nil
+}
+
+func (l *FSFlockLock) Acquire(ctx context.Context, id string) (LockGuard, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	//data := &LockInfo{
+	//	Holder: id,
+	//	Timestamp:   time.Now().Unix(),
+	//}
+	//b, err := data.ToJSON()
+	//if err != nil {
+	//	return nil, fmt.Errorf("error serializing lock info: %v", err)
+	//}
+
+	f, err := os.OpenFile(l.p, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("error opening lock file %q: %v", l.p, err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		if syserr, ok := err.(syscall.Errno); ok {
+			if syserr == syscall.EWOULDBLOCK {
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected result from flock(%s, LOCK_EX): %v", l.p, err)
+	}
+
+	glog.Infof("Acquired FSLock on %s for %s", l.p, id)
+
+	//if _, err := f.WriteAt(b, 0); err != nil {
+	//	f.Close()
+	//	return nil, fmt.Errorf("unexpected result from flock(%s, LOCK_EX): %v", l.p, ret)
+	//}
+
+	return &FSFlockLockGuard{
+		p:    l.p,
+		file: f,
+	}, nil
+}
+
+func (l *FSFlockLockGuard) Release() error {
+	ret := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	if ret != nil {
+		l.file.Close()
+		return fmt.Errorf("unexpected result from flock(%s, LOCK_UN): %v", l.p, ret)
+	}
+
+	if err := l.file.Close(); err != nil {
+		return fmt.Errorf("unexpected result from closing lock file %s: %v", l.p, ret)
+	}
+
+	return nil
+}

--- a/pkg/locking/fs.go
+++ b/pkg/locking/fs.go
@@ -1,0 +1,172 @@
+package locking
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+type FSContentLock struct {
+	p string
+}
+
+var _ Lock = &FSContentLock{}
+
+type FSContentLockGuard struct {
+	p    string
+	file *os.File
+	data []byte
+	id   string
+}
+
+var _ LockGuard = &FSContentLockGuard{}
+
+func NewFSContentLock(p string) (*FSContentLock, error) {
+	return &FSContentLock{
+		p: p,
+	}, nil
+}
+
+func (l *FSContentLock) Acquire(ctx context.Context, id string) (LockGuard, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	data := &LockInfo{
+		Holder:    id,
+		Timestamp: time.Now().Unix(),
+	}
+	b, err := data.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("error serializing lock info: %v", err)
+	}
+
+	hash := sha256.Sum256(b)
+	lockBytes := []byte(hex.EncodeToString(hash[:]) + "\n" + string(b))
+
+	f, err := os.OpenFile(l.p, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("error creating lock file %q: %v", l.p, err)
+	}
+
+	fileBytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		if errC := f.Close(); errC != nil {
+			glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+		}
+		return nil, fmt.Errorf("error reading lock file: %v", err)
+	}
+	if len(fileBytes) != 0 {
+		var existing *LockInfo
+		firstLF := bytes.IndexByte(fileBytes, '\n')
+		if firstLF != -1 {
+			computedHash := sha256.Sum256(fileBytes[firstLF+1:])
+			if string(fileBytes[0:firstLF]) == hex.EncodeToString(computedHash[:]) {
+				existing = &LockInfo{}
+				if errU := json.Unmarshal(fileBytes[firstLF+1:], existing); errU != nil {
+					glog.Warningf("error parsing json %q - will treat as lock not held: %v", string(fileBytes), errU)
+				} else {
+					if errC := f.Close(); errC != nil {
+						glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+					}
+					glog.Warningf("lock is already held %v", existing)
+					return nil, nil
+				}
+			} else {
+				glog.Warningf("hash in file %q did not match: %q", l.p, string(fileBytes))
+			}
+		} else {
+			glog.Warningf("file %q was corrupt: %q", l.p, string(fileBytes))
+		}
+
+		if errT := f.Truncate(0); errT != nil {
+			if errC := f.Close(); errC != nil {
+				glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+			}
+			return nil, fmt.Errorf("failed to truncate file after failed read %q: %v", l.p, errT)
+		}
+	}
+
+	_, err = f.WriteAt(lockBytes, 0)
+	if err != nil {
+		glog.Warningf("error writing file %q: %v", l.p, err)
+	}
+
+	if err == nil {
+		err = f.Sync()
+		if err != nil {
+			glog.Warningf("failed to sync file: %v", err)
+		}
+	}
+
+	if err != nil {
+		glog.Warningf("attempting to truncate file after failed write %q: %v", l.p, err)
+		if errT := f.Truncate(0); errT != nil {
+			glog.Warningf("failed to truncate file after failed write %q: %v", l.p, errT)
+		}
+	}
+
+	if errC := f.Close(); errC != nil {
+		glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating lock file %q: %v", l.p, err)
+	}
+
+	glog.Infof("Acquired FSLock on %s for %s", l.p, id)
+
+	return &FSContentLockGuard{
+		p:    l.p,
+		id:   id,
+		file: f,
+		data: lockBytes,
+	}, nil
+}
+
+func (l *FSContentLockGuard) Release() error {
+	f, errO := os.OpenFile(l.p, os.O_RDWR, 0755)
+	if errO != nil {
+		return fmt.Errorf("error opening file %q: %v", l.p, errO)
+	}
+
+	fileBytes, errR := ioutil.ReadAll(f)
+	if errR != nil {
+		if errC := f.Close(); errC != nil {
+			glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+		}
+		return fmt.Errorf("error reading lock file: %v", errR)
+	}
+
+	if !bytes.Equal(fileBytes, l.data) {
+		if errC := f.Close(); errC != nil {
+			glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+		}
+		return fmt.Errorf("lock file %q changed", l.p)
+	}
+
+	if errT := f.Truncate(0); errT != nil {
+		glog.Warningf("failed to truncate file as part of lock release %q: %v", l.p, errT)
+
+		if errC := f.Close(); errC != nil {
+			glog.Fatalf("error closing lock file %q: %v", l.p, errC)
+		}
+
+		return fmt.Errorf("failed to truncate file after failed write %q: %v", l.p, errT)
+	}
+
+	if errC := f.Close(); errC != nil {
+		return fmt.Errorf("error closing file as part of unlock %q: %v", l.p, errC)
+	}
+
+	glog.Infof("Released FSLock on %q for %s", l.p, l.id)
+
+	return nil
+}

--- a/pkg/locking/info.go
+++ b/pkg/locking/info.go
@@ -1,0 +1,12 @@
+package locking
+
+import "encoding/json"
+
+type LockInfo struct {
+	Holder    string `json:"owner"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+func (l *LockInfo) ToJSON() ([]byte, error) {
+	return json.Marshal(l)
+}

--- a/pkg/locking/interfaces.go
+++ b/pkg/locking/interfaces.go
@@ -1,0 +1,13 @@
+package locking
+
+import "context"
+
+// Lock is the interface for a mutex
+type Lock interface {
+	Acquire(ctx context.Context, id string) (LockGuard, error)
+}
+
+// LockGuard is a lock that is actually held
+type LockGuard interface {
+	Release() error
+}

--- a/pkg/locking/lock_test.go
+++ b/pkg/locking/lock_test.go
@@ -1,0 +1,117 @@
+package locking
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func init() {
+	flag.Set("logtostderr", "true")
+	flag.Set("v", "2")
+	flag.Parse()
+}
+
+func checkLocks(t *testing.T, l1, l2 Lock) {
+	ctx := context.TODO()
+
+	// Should be able to lock the new lock
+	lg1, err := l1.Acquire(ctx, "1")
+	if err != nil {
+		t.Fatalf("unable to acquire new lock: %v", err)
+	}
+	if lg1 == nil {
+		t.Fatalf("lock was unexpected nil")
+	}
+
+	// Second process cannot acquire it
+	lg2, err := l2.Acquire(ctx, "2")
+	if lg2 != nil {
+		t.Fatalf("able to double-lock lock: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("expected no error when failed to aquire lock: %v", err)
+	}
+
+	// Release first lock
+	if err := lg1.Release(); err != nil {
+		t.Fatalf("unable to release lock")
+	}
+
+	// Second process can now acquire it
+	lg2, err = l2.Acquire(ctx, "2")
+	if err != nil {
+		t.Fatalf("unable to acquire new lock: %v", err)
+	}
+	if lg2 == nil {
+		t.Fatalf("lock was unexpected nil")
+	}
+
+	// First process cannot reacquire it
+	lg1, err = l1.Acquire(ctx, "1")
+	if lg1 != nil {
+		t.Fatalf("able to double-lock lock: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("expected no error when failed to aquire lock: %v", err)
+	}
+
+	// Release second lock
+	if err := lg2.Release(); err != nil {
+		t.Fatalf("unable to release lock")
+	}
+
+	// First process can acquire it again
+	lg1, err = l1.Acquire(ctx, "1")
+	if err != nil {
+		t.Fatalf("unable to acquire new lock: %v", err)
+	}
+	if lg1 == nil {
+		t.Fatalf("lock was unexpected nil")
+	}
+
+	// Release lock
+	if err := lg1.Release(); err != nil {
+		t.Fatalf("unable to release lock")
+	}
+}
+
+func TestFSFlockLock(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Errorf("error building tempdir: %v", err)
+	}
+
+	p := filepath.Join(tmpDir, "lock")
+	l1, err := NewFSFlockLock(p)
+	if err != nil {
+		t.Fatalf("error building lock: %v", err)
+	}
+	l2, err := NewFSFlockLock(p)
+	if err != nil {
+		t.Fatalf("error building lock: %v", err)
+	}
+
+	checkLocks(t, l1, l2)
+}
+
+func TestFSContentLock(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Errorf("error building tempdir: %v", err)
+	}
+
+	p := filepath.Join(tmpDir, "lock")
+	l1, err := NewFSContentLock(p)
+	if err != nil {
+		t.Fatalf("error building lock: %v", err)
+	}
+	l2, err := NewFSContentLock(p)
+	if err != nil {
+		t.Fatalf("error building lock: %v", err)
+	}
+
+	checkLocks(t, l1, l2)
+}

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -8,7 +8,6 @@ go_test(
     ],
     importpath = "kope.io/etcd-manager/test/integration",
     deps = [
-        "//pkg/contextutil:go_default_library",
         "//test/integration/harness:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/test/integration/harness/BUILD.bazel
+++ b/test/integration/harness/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/etcd:go_default_library",
         "//pkg/etcdclient:go_default_library",
+        "//pkg/locking:go_default_library",
         "//pkg/privateapi:go_default_library",
         "//vendor/github.com/coreos/etcd/client:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/test/integration/harness/cluster.go
+++ b/test/integration/harness/cluster.go
@@ -20,6 +20,7 @@ type TestHarness struct {
 	T *testing.T
 
 	ClusterName       string
+	LockPath          string
 	BackupStorePath   string
 	DiscoveryStoreDir string
 
@@ -52,6 +53,11 @@ func NewTestHarness(t *testing.T, ctx context.Context) *TestHarness {
 
 	h.BackupStorePath = "file://" + filepath.Join(h.WorkDir, "backupstore")
 	h.DiscoveryStoreDir = filepath.Join(h.WorkDir, "discovery")
+
+	h.LockPath = filepath.Join(h.WorkDir, "lock")
+	if err := os.MkdirAll(h.WorkDir, 0755); err != nil {
+		t.Fatalf("error creating directory %s: %v", h.LockPath, err)
+	}
 
 	return h
 }


### PR DESCRIPTION
If we have access to a shared filesystem (or another suitable shared
store), we can use that to enforce a leadership mutex.