### PR TITLE
Cleaner upgrade: quarantine nodes, then do a backup

### DIFF
--- a/pkg/controller/upgrade.go
+++ b/pkg/controller/upgrade.go
@@ -12,11 +12,7 @@ func (m *EtcdController) stopForUpgrade(parentContext context.Context, clusterSp
 	// We start a new context - this is pretty critical-path
 	ctx := context.Background()
 
-	// Force a backup, even before we start to do anything
-	if _, err := m.doClusterBackup(ctx, clusterSpec, clusterState); err != nil {
-		return false, fmt.Errorf("error doing backup before upgrade/downgrade: %v", err)
-	}
-
+	// Sanity check
 	memberToPeer := make(map[EtcdMemberId]*peer)
 	for memberId, member := range clusterState.members {
 		found := false
@@ -32,124 +28,52 @@ func (m *EtcdController) stopForUpgrade(parentContext context.Context, clusterSp
 		if !found {
 			return false, fmt.Errorf("unable to find peer for %q", member.Name)
 		}
+	}
 
-		if len(clusterState.healthyMembers) != len(clusterState.members) {
-			// This one seems hard to relax
-			return false, fmt.Errorf("cannot upgrade/downgrade cluster when not all members are healthy")
+	if len(clusterState.healthyMembers) != len(clusterState.members) {
+		// This one seems hard to relax
+		return false, fmt.Errorf("cannot upgrade/downgrade cluster when not all members are healthy")
+	}
+
+	if len(clusterState.members) != int(clusterSpec.MemberCount) {
+		// We could relax this, but we probably don't want to
+		return false, fmt.Errorf("cannot upgrade/downgrade cluster when cluster is not at full member count")
+	}
+
+	// Force a backup, even before we start to do anything
+	if _, err := m.doClusterBackup(ctx, clusterSpec, clusterState); err != nil {
+		return false, fmt.Errorf("error doing backup before upgrade/downgrade: %v", err)
+	}
+
+	// We quarantine first, so that we don't have to get down to a single node before it is safe to do a backup
+	if _, err := m.updateQuarantine(ctx, clusterState, true); err != nil {
+		return false, err
+	}
+
+	// We do a backup
+	backupResponse, err := m.doClusterBackup(ctx, clusterSpec, clusterState)
+	if err != nil {
+		return false, err
+	}
+	glog.Infof("backed up cluster as %v", backupResponse)
+
+	// Stop the whole cluster
+	for memberId := range clusterState.members {
+		peer := memberToPeer[memberId]
+		if peer == nil {
+			// We checked this when we built the map
+			panic("peer unexpectedly not found - logic error")
 		}
 
-		if len(clusterState.members) != int(clusterSpec.MemberCount) {
-			// We could relax this, but we probably don't want to
-			return false, fmt.Errorf("cannot upgrade/downgrade cluster when cluster is not at full member count")
+		request := &protoetcd.StopEtcdRequest{
+			ClusterName:     m.clusterName,
+			LeadershipToken: m.leadership.token,
 		}
-
-		// Stop the whole cluster
-		var lastStopped *peer
-		for memberId := range clusterState.members {
-			peer := memberToPeer[memberId]
-			if peer == nil {
-				// We checked this when we built the map
-				panic("peer unexpectedly not found - logic error")
-			}
-
-			request := &protoetcd.StopEtcdRequest{
-				ClusterName:     m.clusterName,
-				LeadershipToken: m.leadership.token,
-			}
-			response, err := peer.rpcStopEtcd(ctx, request)
-			if err != nil {
-				return false, fmt.Errorf("error stopping etcd peer %q: %v", peer.Id, err)
-			}
-			glog.Infof("stopped etcd on peer %q: %v", peer.Id, response)
-			lastStopped = peer
+		response, err := peer.rpcStopEtcd(ctx, request)
+		if err != nil {
+			return false, fmt.Errorf("error stopping etcd peer %q: %v", peer.Id, err)
 		}
-
-		// Do a backup on the peer we stopped last (in a 3 node cluster, we might still commit after we stop the first node)
-		var backupResponse *protoetcd.DoBackupResponse
-		{
-			info := &protoetcd.BackupInfo{
-				ClusterSpec: clusterSpec,
-			}
-			request := &protoetcd.DoBackupRequest{
-				LeadershipToken: m.leadership.token,
-				ClusterName:     m.clusterName,
-				Storage:         m.backupStore.Spec(),
-				Info:            info,
-			}
-
-			var err error
-			backupResponse, err = lastStopped.rpcDoBackup(ctx, request)
-			if err != nil {
-				// TODO: inject faults here during testing
-				return false, fmt.Errorf("failed to do backup: %v", err)
-			} else {
-				glog.V(2).Infof("backup response: %v", backupResponse)
-			}
-		}
-
-		//// Start a new cluster, using the backup
-		//{
-		//	clusterToken := randomToken()
-		//
-		//	var proposedNodes []*protoetcd.EtcdNode
-		//	for _, p := range clusterState.members {
-		//		node := &protoetcd.EtcdNode{
-		//			Name:        p.Name,
-		//			PeerUrls:    p.PeerURLs,
-		//			ClientUrls:  p.ClientURLs,
-		//			EtcdVersion: clusterSpec.EtcdVersion,
-		//		}
-		//		proposedNodes = append(proposedNodes, nodes)
-		//	}
-		//
-		//	for _, member := range clusterState.members {
-		//		peer := memberToPeer[EtcdMemberId(member.Id)]
-		//		if peer == nil {
-		//			// We checked this when we built the map
-		//			panic("peer unexpectedly not found - logic error")
-		//		}
-		//
-		//		joinClusterRequest := &protoetcd.JoinClusterRequest{
-		//			LeadershipToken: m.leadership.token,
-		//			Phase:           protoetcd.Phase_PHASE_PREPARE,
-		//			ClusterName:     m.clusterName,
-		//			ClusterToken:    clusterToken,
-		//			Nodes:           proposedNodes,
-		//		}
-		//
-		//		joinClusterResponse, err := peer.rpcJoinCluster(ctx, joinClusterRequest)
-		//		if err != nil {
-		//			// TODO: Send a CANCEL message for anything PREPAREd?
-		//			return false, fmt.Errorf("error from JoinClusterRequest from peer %q: %v", peer, err)
-		//		}
-		//		glog.V(2).Infof("JoinClusterResponse: %s", joinClusterResponse)
-		//	}
-		//
-		//	for _, member := range clusterState.members {
-		//		peer := memberToPeer[EtcdMemberId(member.Id)]
-		//		if peer == nil {
-		//			// We checked this when we built the map
-		//			panic("peer unexpectedly not found - logic error")
-		//		}
-		//		// Note the we send the message to ourselves
-		//		joinClusterRequest := &protoetcd.JoinClusterRequest{
-		//			LeadershipToken: m.leadership.token,
-		//			Phase:           protoetcd.Phase_PHASE_INITIAL_CLUSTER,
-		//			ClusterName:     m.clusterName,
-		//			ClusterToken:    clusterToken,
-		//			Nodes:           proposedNodes,
-		//		}
-		//
-		//		joinClusterResponse, err := peer.rpcJoinCluster(ctx, joinClusterRequest)
-		//		if err != nil {
-		//			// TODO: Send a CANCEL message for anything PREPAREd?
-		//			return false, fmt.Errorf("error from JoinClusterRequest from peer %q: %v", p.peer, err)
-		//		}
-		//		glog.V(2).Infof("JoinClusterResponse: %s", joinClusterResponse)
-		//	}
-		//}
-		//
-		//// We wait for up to 5 minutes for our new cluster
+		glog.Infof("stopped etcd on peer %q: %v", peer.Id, response)
 	}
 
 	// TODO: Enforce the upgrade sequence 2.2.1 2.3.7 3.0.17 3.1.11

--- a/pkg/etcd/etcdprocess.go
+++ b/pkg/etcd/etcdprocess.go
@@ -189,7 +189,7 @@ func (p *etcdProcess) Client() (etcdclient.EtcdClient, error) {
 func (p *etcdProcess) DoBackup(store backup.Store, info *protoetcd.BackupInfo) (*protoetcd.DoBackupResponse, error) {
 	response := &protoetcd.DoBackupResponse{}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339)
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
 
 	tempDir, err := store.CreateBackupTempDir(timestamp)
 	if err != nil {

--- a/pkg/etcdclient/v3.go
+++ b/pkg/etcdclient/v3.go
@@ -67,7 +67,7 @@ func (c *V3Client) Put(ctx context.Context, key string, value []byte) error {
 	if err != nil {
 		return err
 	}
-	glog.Infof("put %s response %v", key, response)
+	glog.V(4).Infof("put %s response %v", key, response)
 	return nil
 }
 


### PR DESCRIPTION
This avoids us getting into a situation where we have to wait until
we're down to a single node to be sure that we get a backup with the
latest changes.