### PR TITLE
More test cleanups / fixes

### DIFF
--- a/test/integration/clusterformation_test.go
+++ b/test/integration/clusterformation_test.go
@@ -92,7 +92,7 @@ func TestClusterExpansion(t *testing.T) {
 	if err != nil {
 		t.Errorf("error doing etcd ListMembers: %v", err)
 	} else if len(members1) != 2 {
-		t.Errorf("members was not as expected: %v", err)
+		t.Errorf("members was not as expected: %v", members1)
 	} else {
 		glog.Infof("got members from #1: %v", members1)
 	}
@@ -101,7 +101,7 @@ func TestClusterExpansion(t *testing.T) {
 	if err != nil {
 		t.Errorf("error doing etcd ListMembers: %v", err)
 	} else if len(members2) != 2 {
-		t.Errorf("members was not as expected: %v", err)
+		t.Errorf("members was not as expected: %v", members2)
 	} else {
 		glog.Infof("got members from #2: %v", members2)
 	}
@@ -114,7 +114,7 @@ func TestClusterExpansion(t *testing.T) {
 	if err != nil {
 		t.Errorf("error doing etcd ListMembers: %v", err)
 	} else if len(members3) != 3 {
-		t.Errorf("members was not as expected: %v", err)
+		t.Errorf("members was not as expected: %v", members3)
 	} else {
 		glog.Infof("got members from #3: %v", members3)
 	}
@@ -141,7 +141,7 @@ func TestWeOnlyFormASingleCluster(t *testing.T) {
 	if err != nil {
 		t.Errorf("error doing etcd ListMembers: %v", err)
 	} else if len(members1) != 1 {
-		t.Errorf("members was not as expected: %v", err)
+		t.Errorf("members was not as expected: %v", members1)
 	} else {
 		glog.Infof("got members from #1: %v", members1)
 	}

--- a/test/integration/harness/cluster.go
+++ b/test/integration/harness/cluster.go
@@ -108,3 +108,9 @@ func (h *TestHarness) NewNode(address string) *TestHarnessNode {
 func (h *TestHarness) SpecKey() string {
 	return "/kope.io/etcd-manager/" + h.ClusterName + "/spec"
 }
+
+func (h *TestHarness) WaitForHealthy(nodes ...*TestHarnessNode) {
+	for _, node := range nodes {
+		node.WaitForHealthy(10 * time.Second)
+	}
+}

--- a/test/integration/harness/etcd.go
+++ b/test/integration/harness/etcd.go
@@ -64,7 +64,7 @@ func waitForListMembers(t *testing.T, client etcdclient.EtcdClient, timeout time
 			glog.Infof("Got members from %s: (%v)", client, members)
 			return
 		}
-		glog.Infof("Got error reading members from %s: (%v)", client, err)
+		glog.Infof("test waiting for members from %s: (%v)", client, err)
 		if time.Now().After(endAt) {
 			t.Fatalf("list-members did not succeed within %v", timeout)
 			return


### PR DESCRIPTION
Most importantly, waiting for cluster ready before proceeding, not just
for the member list to be returned.