### PR TITLE
Stricter model for changes

### DIFF
--- a/cmd/etcd-manager-ctl/main.go
+++ b/cmd/etcd-manager-ctl/main.go
@@ -54,7 +54,10 @@ func main() {
 		MemberCount: int32(memberCount),
 		EtcdVersion: etcdVersion,
 	}
-	if err := backupStore.SeedNewCluster(spec); err != nil {
+	cmd := &protoetcd.Command{
+		CreateNewCluster: &protoetcd.CreateNewClusterCommand{ClusterSpec: spec},
+	}
+	if err := backupStore.AddCommand(cmd); err != nil {
 		glog.Fatalf("error building etcd controller: %v", err)
 	}
 

--- a/pkg/apis/etcd/etcdapi.proto
+++ b/pkg/apis/etcd/etcdapi.proto
@@ -8,6 +8,32 @@ message ClusterSpec {
     string etcd_version = 2;
 }
 
+message Command {
+    int64 timestamp = 1;
+
+    // If restore backup is set, this indicates a request to restore the specified backup
+    // This is not normally safe (potential for data loss if the backup is out of date),
+    // but either the administrator can set this in a DR scenario,
+    // or we set it ourselves immediately after having performed a quarantined backup
+    RestoreBackupCommand restore_backup = 10;
+
+    // If set, indicates we should create a new (empty) cluster
+    // This is not normally safe, but the administrator can set this in a DR scenario,
+    // and tooling sets it for new clusters
+    CreateNewClusterCommand create_new_cluster = 11;
+}
+
+message RestoreBackupCommand {
+    // The new cluster spec we should restore into
+    ClusterSpec cluster_spec = 1;
+
+    string backup = 3;
+}
+
+message CreateNewClusterCommand {
+    ClusterSpec cluster_spec = 1;
+}
+
 service EtcdManagerService {
     // GetInfo gets info about the node
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);

--- a/pkg/backup/fs.go
+++ b/pkg/backup/fs.go
@@ -16,7 +16,7 @@ import (
 	"kope.io/etcd-manager/pkg/ioutils"
 )
 
-func NewFilesystemStore(u *url.URL) (Store, error) {
+func NewFilesystemStore(u *url.URL) (*filesystemStore, error) {
 	if u.Scheme != "file" {
 		return nil, fmt.Errorf("unexpected scheme for file store %q", u.String())
 	}
@@ -44,7 +44,8 @@ type filesystemStore struct {
 	backupsBase string
 }
 
-var _ Store = &filesystemStore{}
+// We haven't implemented the commands methods, moving to vfs..
+// var _ Store = &filesystemStore{}
 
 func (s *filesystemStore) AddBackup(srcFile string, sequence string, info *etcd.BackupInfo) (string, error) {
 	now := time.Now()

--- a/pkg/backup/store.go
+++ b/pkg/backup/store.go
@@ -9,6 +9,8 @@ import (
 const MetaFilename = "_etcd_backup.meta"
 const DataFilename = "etcd.backup.gz"
 
+const CommandFilename = "_command.json"
+
 type Store interface {
 	Spec() string
 
@@ -27,8 +29,19 @@ type Store interface {
 	// DownloadBackup downloads the backup to the specific file
 	DownloadBackup(name string, destFile string) error
 
-	// SeedNewCluster sets up the "create new cluster" marker, indicating that we should not restore a cluster, but create a new one
-	SeedNewCluster(spec *protoetcd.ClusterSpec) error
+	// AddCommand adds a command to the back of the queue
+	AddCommand(cmd *protoetcd.Command) error
+
+	// ListCommands returns all the external commands that have not been removed
+	ListCommands() ([]*Command, error)
+
+	// RemoveCommand marks a command as complete
+	RemoveCommand(command *Command) error
+}
+
+type Command struct {
+	p    vfs.Path
+	Data protoetcd.Command
 }
 
 func NewStore(storage string) (Store, error) {

--- a/pkg/backup/vfs.go
+++ b/pkg/backup/vfs.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -136,36 +135,30 @@ func (s *vfsStore) LoadInfo(name string) (*etcd.BackupInfo, error) {
 	return spec, nil
 }
 
-func (s *vfsStore) SeedNewCluster(spec *protoetcd.ClusterSpec) error {
-	backups, err := s.ListBackups()
-	if err != nil {
-		return fmt.Errorf("error listing backups: %v", err)
-	}
-	if len(backups) != 0 {
-		return fmt.Errorf("cannot seed new cluster - cluster backups already exists")
-	}
-
-	tmpdir, err := ioutil.TempDir("", "")
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		err := os.RemoveAll(tmpdir)
-		if err != nil {
-			glog.Warningf("error deleting backup temp directory %q: %v", tmpdir, err)
-		}
-	}()
-
-	info := &etcd.BackupInfo{
-		ClusterSpec: spec,
-	}
+func (s *vfsStore) AddCommand(cmd *protoetcd.Command) error {
 	sequence := "000000"
-	name, err := s.AddBackup("", sequence, info)
-	if err != nil {
-		return err
+	now := time.Now()
+
+	cmd.Timestamp = now.UnixNano()
+
+	name := now.UTC().Format(time.RFC3339) + "-" + sequence
+
+	// Save the command file
+	{
+		p := s.backupsBase.Join("commands", name, CommandFilename)
+
+		data, err := etcd.ToJson(cmd)
+		if err != nil {
+			return fmt.Errorf("error marshalling command: %v", err)
+		}
+
+		glog.Infof("Adding command at %s: %v", p, cmd)
+
+		err = p.WriteFile(bytes.NewReader([]byte(data)), nil)
+		if err != nil {
+			return fmt.Errorf("error writing file %q: %v", p.Path(), err)
+		}
 	}
-	glog.Infof("created seed backup with name %q", name)
 
 	return nil
 }
@@ -180,4 +173,56 @@ func (s *vfsStore) DownloadBackup(name string, destFile string) error {
 	srcPath := s.backupsBase.Join(name).Join(DataFilename)
 	destPath := vfs.NewFSPath(destFile)
 	return vfs.CopyFile(srcPath, destPath, nil)
+}
+
+func (s *vfsStore) ListCommands() ([]*Command, error) {
+	commandsBase := s.backupsBase.Join("commands")
+	files, err := commandsBase.ReadTree()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error reading %s: %v", commandsBase.Path(), err)
+	}
+
+	var commands []*Command
+	for _, f := range files {
+		if f.Base() != CommandFilename {
+			continue
+		}
+
+		data, err := f.ReadFile()
+		if err != nil {
+			return nil, fmt.Errorf("error reading %s: %v", f, err)
+		}
+
+		command := &Command{}
+		if err = etcd.FromJson(string(data), &command.Data); err != nil {
+			return nil, fmt.Errorf("error parsing command %q: %v", f, err)
+		}
+		command.p = f
+
+		glog.Infof("read command for %q: %v", f, command.Data.String())
+
+		commands = append(commands, command)
+	}
+
+	sort.Slice(commands, func(i, j int) bool {
+		return commands[i].Data.Timestamp < commands[j].Data.Timestamp
+	})
+
+	glog.Infof("listed commands in %s: %d commands", commandsBase.Path(), len(commands))
+
+	return commands, nil
+}
+
+func (s *vfsStore) RemoveCommand(command *Command) error {
+	p := command.p
+	glog.Infof("deleting command %s", p)
+
+	if err := p.Remove(); err != nil {
+		return fmt.Errorf("error removing command %s: %v", p, err)
+	}
+
+	return nil
 }

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "commands.go",
         "controller.go",
         "etcdclusterstate.go",
         "peer.go",

--- a/pkg/controller/commands.go
+++ b/pkg/controller/commands.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"context"
+
+	"kope.io/etcd-manager/pkg/backup"
+)
+
+func (m *EtcdController) refreshCommands() error {
+	// TODO: Refresh commands less frequently (maybe we need a force flag)
+
+	commands, err := m.backupStore.ListCommands()
+	if err != nil {
+		return err
+	}
+
+	m.commands = commands
+	return nil
+}
+
+func (m *EtcdController) getCreateNewClusterCommand() *backup.Command {
+	for _, c := range m.commands {
+		if c.Data.CreateNewCluster != nil {
+			return c
+		}
+	}
+	return nil
+}
+
+func (m *EtcdController) getRestoreBackupCommand() *backup.Command {
+	for _, c := range m.commands {
+		if c.Data.RestoreBackup != nil {
+			return c
+		}
+	}
+	return nil
+}
+
+func (m *EtcdController) removeCommand(ctx context.Context, cmd *backup.Command) error {
+	return m.backupStore.RemoveCommand(cmd)
+}

--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -139,7 +139,7 @@ func (s *EtcdServer) GetInfo(context.Context, *protoetcd.GetInfoRequest) (*proto
 	response.ClusterName = s.clusterName
 	response.NodeConfiguration = s.etcdNodeConfiguration
 
-	if s.state != nil {
+	if s.state != nil && s.state.Cluster != nil {
 		response.EtcdState = s.state
 	}
 

--- a/test/integration/harness/cluster.go
+++ b/test/integration/harness/cluster.go
@@ -131,7 +131,11 @@ func (h *TestHarness) SeedNewCluster(spec *protoetcd.ClusterSpec) {
 		t.Fatalf("error initializing backup store: %v", err)
 	}
 
-	if err := backupStore.SeedNewCluster(spec); err != nil {
+	cmd := &protoetcd.Command{
+		CreateNewCluster: &protoetcd.CreateNewClusterCommand{ClusterSpec: spec},
+	}
+
+	if err := backupStore.AddCommand(cmd); err != nil {
 		t.Fatalf("error seeding cluster: %v", err)
 	}
 }


### PR DESCRIPTION
We run all changes through the etcd spec, and avoid making any dangerous
changes without an explicit command.  The commands are stored in a queue
on VFS (in the backup store).