### PR TITLE
Make control store the store of spec

### DIFF
--- a/pkg/controller/upgrade.go
+++ b/pkg/controller/upgrade.go
@@ -70,12 +70,12 @@ func (m *EtcdController) stopForUpgrade(parentContext context.Context, clusterSp
 			},
 		}
 
-		if err := m.commandStore.AddCommand(cmd); err != nil {
+		if err := m.controlStore.AddCommand(cmd); err != nil {
 			return false, fmt.Errorf("error adding restore command: %v", err)
 		}
 
 		for {
-			if err := m.refreshCommands(time.Duration(0)); err != nil {
+			if err := m.refreshControlStore(time.Duration(0)); err != nil {
 				return false, fmt.Errorf("error refreshing commands: %v", err)
 			}
 			if m.getRestoreBackupCommand() != nil {

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "clusterformation_test.go",
         "datapersists_test.go",
         "etcdinstalled_test.go",
+        "resize_cluster_test.go",
         "upgradedowngrade_test.go",
     ],
     deps = [

--- a/test/integration/resize_cluster_test.go
+++ b/test/integration/resize_cluster_test.go
@@ -10,48 +10,46 @@ import (
 	"kope.io/etcd-manager/test/integration/harness"
 )
 
-func TestUpgradeDowngrade(t *testing.T) {
+func TestResizeCluster(t *testing.T) {
 	ctx := context.TODO()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*180)
 
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "2.2.1"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
 	go n1.Run()
-	n2 := h.NewNode("127.0.0.2")
-	go n2.Run()
-	n3 := h.NewNode("127.0.0.3")
-	go n3.Run()
 
 	testKey := "/testkey"
 
 	{
 		n1.WaitForListMembers(60 * time.Second)
-		h.WaitForHealthy(n1, n2, n3)
+		h.WaitForHealthy(n1)
 		members1, err := n1.ListMembers(ctx)
 		if err != nil {
 			t.Errorf("error doing etcd ListMembers: %v", err)
-		} else if len(members1) != 3 {
+		} else if len(members1) != 1 {
 			t.Errorf("members was not as expected: %v", members1)
 		} else {
 			glog.Infof("got members from #1: %v", members1)
 		}
 
-		if err := n1.Put(ctx, testKey, "worldv2"); err != nil {
+		if err := n1.Put(ctx, testKey, "singlev2"); err != nil {
 			t.Fatalf("unable to set test key: %v", err)
 		}
 
 		n1.AssertVersion(t, "2.2.1")
-		n2.AssertVersion(t, "2.2.1")
-		n3.AssertVersion(t, "2.2.1")
 	}
 
-	// Upgrade to 3.2.12
-	glog.Infof("upgrading to 3.2.12")
+	n2 := h.NewNode("127.0.0.2")
+	go n2.Run()
+	n3 := h.NewNode("127.0.0.3")
+	go n3.Run()
+
+	glog.Infof("expanding to cluster size 3")
 	{
 		h.SetClusterSpec(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.2.12"})
 		h.InvalidateControlStore(n1, n2, n3)
@@ -81,57 +79,13 @@ func TestUpgradeDowngrade(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error reading test key after upgrade: %v", err)
 		}
-		if v != "worldv2" {
+		if v != "singlev2" {
 			t.Fatalf("unexpected test key value after upgrade: %q", v)
-		}
-
-		if err := n1.Put(ctx, testKey, "worldv3"); err != nil {
-			t.Fatalf("unable to set test key: %v", err)
 		}
 
 		n1.AssertVersion(t, "3.2.12")
 		n2.AssertVersion(t, "3.2.12")
 		n3.AssertVersion(t, "3.2.12")
-	}
-
-	// Downgrade to 2.2.1
-	glog.Infof("downgrading to 2.2.1")
-	{
-		h.SetClusterSpec(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "2.2.1"})
-		h.InvalidateControlStore(n1, n2, n3)
-
-		n1.EtcdVersion = "2.2.1"
-		n2.EtcdVersion = "2.2.1"
-		n3.EtcdVersion = "2.2.1"
-	}
-
-	// Check cluster is stable (on the v2 api)
-	{
-		n1.WaitForListMembers(60 * time.Second)
-		h.WaitForHealthy(n1, n2, n3)
-		members1, err := n1.ListMembers(ctx)
-		if err != nil {
-			t.Errorf("error doing etcd ListMembers: %v", err)
-		} else if len(members1) != 3 {
-			t.Errorf("members was not as expected: %v", members1)
-		} else {
-			glog.Infof("got members from #1: %v", members1)
-		}
-	}
-
-	// Sanity check values
-	{
-		v, err := n1.GetQuorum(ctx, testKey)
-		if err != nil {
-			t.Fatalf("error reading test key after downgrade: %v", err)
-		}
-		if v != "worldv3" {
-			t.Fatalf("unexpected test key value after upgrade: %q", v)
-		}
-
-		n1.AssertVersion(t, "2.2.1")
-		n2.AssertVersion(t, "2.2.1")
-		n3.AssertVersion(t, "2.2.1")
 	}
 
 	cancel()


### PR DESCRIPTION
We don't store a secondary copy in etcd, because if we do it is hard to
update particularly when it must be updateable when etcd is down.