### PR TITLE
Explicitly specify go version to use

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,9 @@ http_archive(
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
-go_register_toolchains()
+go_register_toolchains(
+    go_version="1.10.3",
+)
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 gazelle_dependencies()
 


### PR DESCRIPTION
Otherwise we are implicitly going by the bazel rules version