### PR TITLE
Ensure cluster is consistently quarantined

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -250,6 +250,7 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 	// Number of peers that are configured as part of this cluster
 	configuredMembers := 0
 	quarantinedMembers := 0
+	nonQuarantinedMembers := 0
 	for _, peer := range clusterState.peers {
 		if peer.info == nil {
 			continue
@@ -263,6 +264,8 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 
 			if peer.info.EtcdState.Quarantined {
 				quarantinedMembers++
+			} else {
+				nonQuarantinedMembers++
 			}
 		}
 	}
@@ -368,6 +371,12 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 				glog.Infof("insufficient peers to lift quarantine")
 				return false, nil
 			}
+		}
+
+		// Ensure that if anyone is quarantined (and should be) that everyone is quarantined
+		if nonQuarantinedMembers > 0 {
+			glog.Infof("inconsistent quarantine state, will set all to quarantined")
+			return m.updateQuarantine(ctx, clusterState, true)
 		}
 	}
 

--- a/pkg/controller/upgrade.go
+++ b/pkg/controller/upgrade.go
@@ -48,7 +48,7 @@ func (m *EtcdController) stopForUpgrade(parentContext context.Context, clusterSp
 	}
 
 	// We quarantine first, so that we don't have to get down to a single node before it is safe to do a backup
-	glog.Infof("quaranting cluster for upgrade")
+	glog.Infof("quarantining cluster for upgrade")
 	if _, err := m.updateQuarantine(ctx, clusterState, true); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
If we end up in a state where some nodes are quarantined but others
are not, move to a state where all are quarantined.

This should allow us to recover from a state where we failed to lift
or raise the quarantine.