### PR TITLE
Refactor test to create etcdclient consistently

### DIFF
--- a/test/integration/harness/etcd.go
+++ b/test/integration/harness/etcd.go
@@ -74,7 +74,7 @@ func waitForListMembers(t *testing.T, client etcdclient.EtcdClient, timeout time
 }
 
 func (n *TestHarnessNode) WaitForQuorumRead(ctx context.Context, timeout time.Duration) {
-	client, err := etcdclient.NewClient(n.EtcdVersion, []string{n.ClientURL})
+	client, err := n.NewClient()
 	if err != nil {
 		n.TestHarness.T.Fatalf("error building etcd client: %v", err)
 	}

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -169,7 +169,7 @@ func (n *TestHarnessNode) Run() {
 }
 
 func (n *TestHarnessNode) WaitForListMembers(timeout time.Duration) {
-	client, err := etcdclient.NewClient(n.EtcdVersion, []string{n.ClientURL})
+	client, err := n.NewClient()
 	if err != nil {
 		n.TestHarness.T.Fatalf("error building etcd client: %v", err)
 	}
@@ -178,7 +178,7 @@ func (n *TestHarnessNode) WaitForListMembers(timeout time.Duration) {
 }
 
 func (n *TestHarnessNode) ListMembers(ctx context.Context) ([]*etcdclient.EtcdProcessMember, error) {
-	client, err := etcdclient.NewClient(n.EtcdVersion, []string{n.ClientURL})
+	client, err := n.NewClient()
 	if err != nil {
 		n.TestHarness.T.Fatalf("error building etcd client: %v", err)
 	}
@@ -204,7 +204,7 @@ func (n *TestHarnessNode) Close() error {
 func (n *TestHarnessNode) AssertVersion(t *testing.T, version string) {
 	ctx := context.TODO()
 
-	client, err := etcdclient.NewClient(n.EtcdVersion, []string{n.ClientURL})
+	client, err := n.NewClient()
 	if err != nil {
 		n.TestHarness.T.Fatalf("error building etcd client: %v", err)
 	}
@@ -223,7 +223,7 @@ func (n *TestHarnessNode) WaitForHealthy(timeout time.Duration) {
 
 	endAt := time.Now().Add(timeout)
 	for {
-		client, err := etcdclient.NewClient(n.EtcdVersion, []string{n.ClientURL})
+		client, err := n.NewClient()
 		if err != nil {
 			n.TestHarness.T.Fatalf("error building etcd client: %v", err)
 		}


### PR DESCRIPTION
Should be a no-op refactor, and sets us up to enable TLS.