### PR TITLE
Always add 127.0.0.1 to certificate SANs

### DIFF
--- a/pkg/etcd/pki.go
+++ b/pkg/etcd/pki.go
@@ -113,5 +113,8 @@ func addAltNames(certConfig *certutil.Config, urls []string) error {
 		}
 	}
 
+	// We always self-sign for 127.0.0.1, so that we can always be reached by apiserver / debug clients
+	certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, net.ParseIP("127.0.0.1"))
+
 	return nil
 }


### PR DESCRIPTION
This way we can still query it locally.