### PR TITLE
Use go 1.11.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.10.3",
+    go_version = "1.11.4",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")


### PR DESCRIPTION
We were seeing some concurrent map writes under the stress-test
otherwise, in the http stack it looked like.