### PR TITLE
Build etcd2 from source

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,3 +76,24 @@ http_file(
     sha256 = "947849dbcfa13927c81236fb76a7c01d587bbab42ab1e807184cd91b026ebed7",
     url = "https://github.com/coreos/etcd/releases/download/v3.2.24/etcd-v3.2.24-linux-amd64.tar.gz",
 )
+
+
+#=============================================================================
+# Build etcd from source
+# This picks up a number of critical bug fixes, for example:
+#  * Caching of /etc/hosts https://github.com/golang/go/issues/13340
+#  * General GC etc improvements
+#  * Misc security fixes that are not backported
+
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+# Download via HTTP
+go_repository(
+  name = "etcd_v2_2_1_source",
+  urls = ["https://github.com/etcd-io/etcd/archive/v2.2.1.tar.gz"],
+  sha256 = "1c0ce63812ef951f79c0a544c91f9f1ba3c6b50cb3e8197de555732454864d05",
+  importpath="github.com/coreos/etcd",
+  strip_prefix="etcd-2.2.1/",
+  build_external="vendored",
+  build_file_proto_mode="disable_global",
+)

--- a/images/BUILD
+++ b/images/BUILD
@@ -3,18 +3,64 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
+    "container_layer",
     "container_push",
+)
+
+# Layer for etcd 2.2.1, the version of etcd2 that was recommended
+container_layer(
+    name = "etcd-2-2-1-layer",
+    directory = "/opt/etcd-v2.2.1-linux-amd64/",
+    files = [
+        "@etcd_v2_2_1_source//:etcd",
+        "@etcd_v2_2_1_source//etcdctl",
+    ],
+)
+
+#container_layer(
+#    name = "etcd-2-2-1-layer-upstream",
+#    directory = "/opt/",
+#    tars = [
+#        "@etcd_2_2_1_tar//file",
+#],
+#)
+
+# Layer for etcd 3.1.12, as used in k8s 1.10
+container_layer(
+    name = "etcd-3-1-12-layer",
+    directory = "/opt/",
+    tars = [
+        "@etcd_3_1_12_tar//file",
+    ],
+)
+
+# Layer for etcd 3.2.18, as originally used in k8s 1.11
+container_layer(
+    name = "etcd-3-2-18-layer",
+    directory = "/opt/",
+    tars = [
+        "@etcd_3_2_18_tar//file",
+    ],
+)
+
+# Layer for etcd 3.2.24, updated recommendation for k8s 1.11 and later
+container_layer(
+    name = "etcd-3-2-24-layer",
+    directory = "/opt/",
+    tars = [
+        "@etcd_3_2_24_tar//file",
+    ],
 )
 
 container_image(
     name = "etcd-manager-base",
     base = "@debian_base_amd64//image",
     directory = "/opt",
-    tars = [
-        "@etcd_2_2_1_tar//file",  # etcd2 version
-        "@etcd_3_1_12_tar//file",  # k8s 1.10
-        "@etcd_3_2_18_tar//file",  # original k8s 1.11
-        "@etcd_3_2_24_tar//file",  # updated recommendation for k8s 1.11 and later
+    layers = [
+        "etcd-2-2-1-layer",
+        "etcd-3-1-12-layer",
+        "etcd-3-2-18-layer",
+        "etcd-3-2-24-layer",
     ],
 )
 


### PR DESCRIPTION
This means we know what we're getting, that we can support multiple
architectures, but also that we pick up some critical bug fixes -
particularly around caching of /etc/hosts