### PR TITLE
Raise the time limit for the upgrade/downgrade test

### DIFF
--- a/test/integration/upgradedowngrade_test.go
+++ b/test/integration/upgradedowngrade_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUpgradeDowngrade(t *testing.T) {
 	ctx := context.TODO()
-	ctx, cancel := context.WithTimeout(ctx, time.Second*180)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*240)
 
 	defer cancel()
 


### PR DESCRIPTION
It was timing out on travis, I believe because it's a less
powerful/more heavily loaded machine.