### PR TITLE
Allow for incorrect ClientURLs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -593,7 +593,7 @@ func (m *EtcdController) updateClusterState(ctx context.Context, peers []*peer) 
 		if p.info.EtcdState.Quarantined {
 			clientUrls = p.info.NodeConfiguration.QuarantinedClientUrls
 		}
-		if len(p.info.NodeConfiguration.ClientUrls) == 0 {
+		if len(clientUrls) == 0 {
 			continue
 		}
 
@@ -625,7 +625,7 @@ func (m *EtcdController) updateClusterState(ctx context.Context, peers []*peer) 
 	clusterState.healthyMembers = make(map[EtcdMemberId]*etcdclient.EtcdProcessMember)
 	//clusterState.versions = make(map[EtcdMemberId]*version.Versions)
 	for id, member := range clusterState.members {
-		etcdClient, err := member.NewClient(m.etcdClientTLSConfig)
+		etcdClient, err := clusterState.newEtcdClient(member)
 		if err != nil {
 			glog.Warningf("health-check unable to reach member %s: %v", id, err)
 			continue

--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -514,6 +515,15 @@ func (s *EtcdServer) startEtcdProcess(state *protoetcd.EtcdState) error {
 	}
 	if meNode == nil {
 		return fmt.Errorf("self node was not included in cluster")
+	}
+
+	if !reflect.DeepEqual(s.etcdNodeConfiguration.ClientUrls, meNode.ClientUrls) {
+		glog.Infof("overriding clientURLs with %v (state had %v)", s.etcdNodeConfiguration.ClientUrls, meNode.ClientUrls)
+		meNode.ClientUrls = s.etcdNodeConfiguration.ClientUrls
+	}
+	if !reflect.DeepEqual(s.etcdNodeConfiguration.QuarantinedClientUrls, meNode.QuarantinedClientUrls) {
+		glog.Infof("overriding quarantinedClientURLs with %v (state had %v)", s.etcdNodeConfiguration.QuarantinedClientUrls, meNode.QuarantinedClientUrls)
+		meNode.QuarantinedClientUrls = s.etcdNodeConfiguration.QuarantinedClientUrls
 	}
 
 	p := &etcdProcess{

--- a/pkg/etcdclient/member.go
+++ b/pkg/etcdclient/member.go
@@ -8,8 +8,10 @@ import (
 
 type EtcdProcessMember struct {
 	//Id         string   `json:"id,omitempty"`
-	Name       string   `json:"name,omitempty"`
-	PeerURLs   []string `json:"peerURLs,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	PeerURLs []string `json:"peerURLs,omitempty"`
+	// ClientURLs is the set of URLs as reported by the cluster.
+	// Note that it might be incorrect, because the ClientURLs are stored in Raft, but can be reconfigured from the command line
 	ClientURLs []string `json:"endpoints,omitempty"`
 
 	etcdVersion string
@@ -19,8 +21,8 @@ type EtcdProcessMember struct {
 	idv3 uint64
 }
 
-func (m *EtcdProcessMember) NewClient(tlsConfig *tls.Config) (EtcdClient, error) {
-	return NewClient(m.etcdVersion, m.ClientURLs, tlsConfig)
+func (m *EtcdProcessMember) NewClient(clientURLs []string, tlsConfig *tls.Config) (EtcdClient, error) {
+	return NewClient(m.etcdVersion, clientURLs, tlsConfig)
 }
 
 func (m *EtcdProcessMember) String() string {


### PR DESCRIPTION
ClientURLs can be controlled by etcd command line flags, and when that
happens the member information stored in etcd might be out of date.
So we have to be much more careful in building the list of client
urls.