### PR TITLE
Guard against no client urls

### DIFF
--- a/pkg/etcdclient/interfaces.go
+++ b/pkg/etcdclient/interfaces.go
@@ -55,6 +55,10 @@ type LocalNodeInfo struct {
 }
 
 func NewClient(etcdVersion string, clientURLs []string, tlsConfig *tls.Config) (EtcdClient, error) {
+	if len(clientURLs) == 0 {
+		return nil, fmt.Errorf("no client URLs were provided")
+	}
+
 	if IsV2(etcdVersion) {
 		return NewV2Client(clientURLs, tlsConfig)
 	}


### PR DESCRIPTION
Fail-fast if we try to build a client with no URLs