### PR TITLE
GRPC: limit backoff in gossip communications

### DIFF
--- a/pkg/privateapi/peers.go
+++ b/pkg/privateapi/peers.go
@@ -233,6 +233,8 @@ func (p *peer) connect() (*grpc.ClientConn, error) {
 		opts = append(opts, grpc.WithInsecure())
 	}
 
+	opts = append(opts, grpc.WithBackoffMaxDelay(10*time.Second))
+
 	endpoints := make(map[string]bool)
 	{
 		p.mutex.Lock()


### PR DESCRIPTION
Our gossip network is assumed to be reasonably low latency (it has to
support etcd!), so we reduce the maximum backoff for GRPC.