### PR TITLE
etcd3 client - use much shorter timeouts

### DIFF
--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -168,15 +168,6 @@ func (n *TestHarnessNode) Run() {
 	}
 }
 
-func (n *TestHarnessNode) WaitForListMembers(timeout time.Duration) {
-	client, err := n.NewClient()
-	if err != nil {
-		n.TestHarness.T.Fatalf("error building etcd client: %v", err)
-	}
-	defer client.Close()
-	waitForListMembers(n.TestHarness.T, client, timeout)
-}
-
 func (n *TestHarnessNode) ListMembers(ctx context.Context) ([]*etcdclient.EtcdProcessMember, error) {
 	client, err := n.NewClient()
 	if err != nil {


### PR DESCRIPTION
The shorter timeouts help us detect failed etcd nodes faster.