### PR TITLE
Don't forget to call client.Close()

### DIFF
--- a/pkg/backupcontroller/controller.go
+++ b/pkg/backupcontroller/controller.go
@@ -77,6 +77,7 @@ func (m *BackupController) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to reach etcd on %s: %v", m.clientUrls, err)
 	}
+
 	members, err := etcdClient.ListMembers(ctx)
 	if err != nil {
 		etcdclient.LoggedClose(etcdClient)

--- a/pkg/etcd/backup.go
+++ b/pkg/etcd/backup.go
@@ -112,6 +112,7 @@ func DoBackupV3(backupStore backup.Store, info *protoetcd.BackupInfo, clientUrls
 	if err != nil {
 		return nil, fmt.Errorf("error building etcd client to etcd: %v", err)
 	}
+	defer etcdclient.LoggedClose(client)
 
 	snapshotFile := filepath.Join(tempDir, "snapshot.db.gz")
 	glog.Infof("performing snapshot save to %s", snapshotFile)

--- a/test/integration/harness/etcd.go
+++ b/test/integration/harness/etcd.go
@@ -22,6 +22,7 @@ func (n *TestHarnessNode) get(ctx context.Context, key string, quorum bool) (str
 	if err != nil {
 		return "", err
 	}
+	defer client.Close()
 
 	response, err := client.Get(ctx, key, quorum)
 	if err != nil {

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -222,10 +222,6 @@ func (n *TestHarnessNode) ListMembers(ctx context.Context) ([]*etcdclient.EtcdPr
 	if err != nil {
 		return nil, fmt.Errorf("error building etcd client: %v", err)
 	}
-
-	if client == nil {
-		return nil, fmt.Errorf("unable to build etcd client")
-	}
 	defer client.Close()
 
 	return client.ListMembers(ctx)
@@ -262,6 +258,7 @@ func (n *TestHarnessNode) AssertVersion(t *testing.T, version string) {
 		n.TestHarness.T.Fatalf("error building etcd client: %v", err)
 	}
 	defer client.Close()
+
 	actual, err := client.ServerVersion(ctx)
 	if err != nil {
 		t.Fatalf("error getting version from node: %v", err)

--- a/test/integration/upgradedowngrade_test.go
+++ b/test/integration/upgradedowngrade_test.go
@@ -145,6 +145,8 @@ func TestUpgradeDowngrade(t *testing.T) {
 					n3.AssertVersion(t, fromVersion)
 				}
 
+				glog.Infof("success!")
+
 				cancel()
 				h.Close()
 			})


### PR DESCRIPTION
Added a few places where I forgot this - mostly tests, but also some backup code paths.