### PR TITLE
Support TLS for etcd backups

### DIFF
--- a/images/BUILD
+++ b/images/BUILD
@@ -82,7 +82,6 @@ container_push(
     image = ":etcd-manager",
     registry = "{STABLE_DOCKER_REGISTRY}",
     repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager",
-    stamp = True,
     tag = "{STABLE_DOCKER_TAG}",
 )
 
@@ -101,7 +100,6 @@ container_push(
     image = ":etcd-dump",
     registry = "{STABLE_DOCKER_REGISTRY}",
     repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump",
-    stamp = True,
     tag = "{STABLE_DOCKER_TAG}",
 )
 
@@ -120,6 +118,5 @@ container_push(
     image = ":etcd-backup",
     registry = "{STABLE_DOCKER_REGISTRY}",
     repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup",
-    stamp = True,
     tag = "{STABLE_DOCKER_TAG}",
 )

--- a/pkg/backupcontroller/controller.go
+++ b/pkg/backupcontroller/controller.go
@@ -64,7 +64,7 @@ func (m *BackupController) Run(ctx context.Context) {
 func (m *BackupController) run(ctx context.Context) error {
 	glog.V(2).Infof("starting backup controller iteration")
 
-	etcdVersion, err := etcdclient.ServerVersion(ctx, m.clientUrls)
+	etcdVersion, err := etcdclient.ServerVersion(ctx, m.clientUrls, m.etcdClientTLSConfig)
 	if err != nil {
 		return fmt.Errorf("unable to find server version of etcd on %s: %v", m.clientUrls, err)
 	}


### PR DESCRIPTION
The following flags are made available for etcd-backup:
```
client-ca-file: Path to a CA cert file to validate the Server Certificate
client-cert-file: Path to the etcd client TLS Certificate file
client-key-file: Path to the etcd client TLS Certificate Key file
```

Fixes #189