### PR TITLE
Fix unexpected etcd image error if docker pulls images over proxy

### DIFF
--- a/pkg/legacy/adopt.go
+++ b/pkg/legacy/adopt.go
@@ -120,7 +120,7 @@ func ImportExistingEtcd(baseDir string, etcdNodeConfiguration *protoetcd.EtcdNod
 		// Extract version from image
 		{
 			tokens := strings.Split(etcdContainer.Image, ":")
-			if len(tokens) != 2 {
+			if len(tokens) != 2 && len(tokens) != 3 {
 				return nil, fmt.Errorf("unexpected etcd image %q", etcdContainer.Image)
 			}
 			state.EtcdVersion = tokens[1]

--- a/pkg/legacy/adopt.go
+++ b/pkg/legacy/adopt.go
@@ -120,10 +120,15 @@ func ImportExistingEtcd(baseDir string, etcdNodeConfiguration *protoetcd.EtcdNod
 		// Extract version from image
 		{
 			tokens := strings.Split(etcdContainer.Image, ":")
-			if len(tokens) != 2 && len(tokens) != 3 {
+			if len(tokens) == 2 {
+				state.EtcdVersion = tokens[1]
+			} else if len(tokens) == 3 {
+				// This is valid when pulling from proxies/mirrors with ports
+				// localhost:8000/etcd:3.3.3
+				state.EtcdVersion = tokens[2]
+			} else {
 				return nil, fmt.Errorf("unexpected etcd image %q", etcdContainer.Image)
 			}
-			state.EtcdVersion = tokens[1]
 		}
 
 		etcdName := strings.TrimSpace(etcdContainer.FindEnv("ETCD_NAME"))


### PR DESCRIPTION
I tried to use etcd-manager in kops which is setup to use a proxy to pull docker images.
```
spec:
  assets:
    containerProxy: nexus.internal:8500
```


But starting etcd-manager would always abort with `error initializing etcd server: unexpected etcd image \“nexus.internal:8500/etcd:2.2.1\“`

The two colons do incorrectly let a check fail to verify the specified name of the etcd docker image.