### PR TITLE
Added instructions and script to release etcd-manager-ctl binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ bazel-testlogs
 # We often create some local symlinks
 /etcd-manager
 /etcd-manager-ctl
+
+# Release assets
+dist/

--- a/dev/build-assets.sh
+++ b/dev/build-assets.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+VERSION=$1
+PLATFORMS="linux_amd64 darwin_amd64 windows_amd64"
+CMDS="etcd-manager-ctl"
+
+# Ensure the dist folder exists and is clean
+rm -fr dist/${VERSION} && mkdir -p dist/${VERSION}
+
+for CMD in ${CMDS}; do
+    for PLATFORM in ${PLATFORMS}; do
+        CMD_DIST_PATH="dist/${VERSION}/${CMD}-${PLATFORM/_/-}"
+
+        # Get the expected binary file extension
+        if [[ "${PLATFORM}" =~ "windows" ]]; then
+            EXTENSION=".exe"
+        else
+            EXTENSION=""
+        fi
+
+        # Build
+        bazel build --platforms=@io_bazel_rules_go//go/toolchain:${PLATFORM} //cmd/${CMD}
+
+        if [ -e "bazel-bin/cmd/${CMD}/${PLATFORM}_stripped/${CMD}${EXTENSION}" ]; then
+            cp bazel-bin/cmd/${CMD}/${PLATFORM}_stripped/${CMD}${EXTENSION} ${CMD_DIST_PATH}
+        elif [ -e "bazel-bin/cmd/${CMD}/${PLATFORM}_pure_stripped/${CMD}${EXTENSION}" ]; then
+            cp bazel-bin/cmd/${CMD}/${PLATFORM}_pure_stripped/${CMD}${EXTENSION} ${CMD_DIST_PATH}
+        else
+            echo "Unable to find compiled binary for ${CMD} ${PLATFORM}"
+            exit 1
+        fi
+
+        # Generate SHA-256
+        shasum -a 256 ${CMD_DIST_PATH} | cut -d ' ' -f 1 > ${CMD_DIST_PATH}-sha-256
+    done
+done

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 TODAY=`date +%Y%m%d`
+VERSION="3.0.${TODAY}"
+
 echo "# Run these commands to do a release"
-echo "DOCKER_IMAGE_PREFIX=kopeio/ DOCKER_TAG=3.0.${TODAY} make push"
+echo "DOCKER_IMAGE_PREFIX=kopeio/ DOCKER_TAG=${VERSION} make push"
 echo "DOCKER_IMAGE_PREFIX=kopeio/ DOCKER_TAG=latest make push"
-echo "git tag 3.0.${TODAY}"
+echo "git tag ${VERSION}"
 echo "git push --tags ssh://git@github.com/kopeio/etcd-manager"
+echo "./dev/build-assets.sh ${VERSION}"
+echo "# Finally, create a new release on GitHub attaching binary assets at dist/${VERSION}/"


### PR DESCRIPTION
Engineers may require `etcd-manager-ctl` to manage backups (ie. issue a restore command). Contrary to `etcd-manager` which gets shipped in a Docker image, `etcd-manager-ctl` is not strictly required to run in the same container while it can be run on any system having access to the remote storage (ie. engineer's workstation with privileges to read/write the related S3 bucket).

In this PR I'm proposing to release `etcd-manager-ctl` binaries via GitHub release's assets. I haven't found any automatism to create the GitHub release, so I've assumed it's created manually at this stage.

Fixes https://github.com/kopeio/etcd-manager/issues/201.