### PR TITLE
Add etcd-manager-ctl and etcd-backup-ctl to their respective images.

### DIFF
--- a/images/BUILD
+++ b/images/BUILD
@@ -84,6 +84,7 @@ container_image(
     entrypoint = ["/etcd-manager"],
     files = [
         "//cmd/etcd-manager",
+        "//cmd/etcd-manager-ctl",
     ],
 )
 
@@ -120,6 +121,7 @@ container_image(
     entrypoint = ["/etcd-backup"],
     files = [
         "//cmd/etcd-backup",
+        "//cmd/etcd-backup-ctl",
     ],
 )
 

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "large",  # Takes more than 300 seconds to run on travis
+    size = "enormous",  # Takes more than 900 seconds to run on travis
     srcs = [
         "clusterformation_test.go",
         "datapersists_test.go",


### PR DESCRIPTION
Add etcd-manager-ctl and etcd-backup-ctl to their respective images.

This will make it easier to for users to get a hold of the binaries where they are needed.