### PR TITLE
Add etcd 3.3.13

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -61,3 +61,14 @@ gazelle(
     "etcd",
     "etcdctl",
 ]]
+
+[genrule(
+    name = "etcd-v3.3.13-linux-amd64_%s" % c,
+    srcs = ["@etcd_3_3_13_tar//file"],
+    outs = ["etcd-v3.3.13-linux-amd64/%s" % c],
+    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_3_13_tar//file) etcd-v3.3.13-linux-amd64/%s && mv etcd-v3.3.13-linux-amd64/%s \"$@\"" % (c, c),
+    visibility = ["//visibility:public"],
+) for c in [
+    "etcd",
+    "etcdctl",
+]]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,6 +83,12 @@ http_file(
     urls = ["https://github.com/coreos/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz"],
 )
 
+http_file(
+    name = "etcd_3_3_13_tar",
+    sha256 = "2c2e2a9867c1c61697ea0d8c0f74c7e9f1b1cf53b75dff95ca3bc03feb19ea7e",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.3.13/etcd-v3.3.13-linux-amd64.tar.gz"],
+)
+
 #=============================================================================
 # Build etcd from source
 # This picks up a number of critical bug fixes, for example:

--- a/images/BUILD
+++ b/images/BUILD
@@ -65,6 +65,16 @@ container_layer(
     ],
 )
 
+# Layer for etcd 3.3.13, updated recommendation for k8s 1.14 and later
+container_layer(
+    name = "etcd-3-3-13-layer",
+    directory = "/opt/etcd-v3.3.13-linux-amd64/",
+    files = [
+        "//:etcd-v3.3.13-linux-amd64_etcdctl",
+        "//:etcd-v3.3.13-linux-amd64_etcd",
+    ],
+)
+
 container_image(
     name = "etcd-manager-base",
     base = "@debian_base_amd64//image",
@@ -75,6 +85,7 @@ container_image(
         "etcd-3-2-18-layer",
         "etcd-3-2-24-layer",
         "etcd-3-3-10-layer",
+        "etcd-3-3-13-layer",
     ],
 )
 

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -22,6 +22,8 @@ go_test(
         "//:etcd-v3.2.24-linux-amd64_etcdctl",
         "//:etcd-v3.3.10-linux-amd64_etcd",
         "//:etcd-v3.3.10-linux-amd64_etcdctl",
+        "//:etcd-v3.3.13-linux-amd64_etcd",
+        "//:etcd-v3.3.13-linux-amd64_etcdctl",
     ],
     deps = [
         "//pkg/apis/etcd:go_default_library",

--- a/test/integration/clusterformation_test.go
+++ b/test/integration/clusterformation_test.go
@@ -17,7 +17,7 @@ func init() {
 	flag.Parse()
 }
 
-var AllEtcdVersions = []string{"2.2.1", "3.1.12", "3.2.18", "3.2.24", "3.3.10"}
+var AllEtcdVersions = []string{"2.2.1", "3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13"}
 
 func TestClusterWithOneMember(t *testing.T) {
 	for _, etcdVersion := range AllEtcdVersions {


### PR DESCRIPTION
Potential fix for https://github.com/kubernetes/kops/issues/6875.

Fix potential grpc leak:
https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3311-2019-1-11

Test seems to be timing out due to length