### PR TITLE
Support listen-metrics-urls option

### DIFF
--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -69,6 +69,7 @@ func main() {
 	flag.StringVar(&o.Address, "address", o.Address, "local address to use")
 	flag.StringVar(&o.PeerUrls, "peer-urls", o.PeerUrls, "peer-urls to use")
 	flag.IntVar(&o.GrpcPort, "grpc-port", o.GrpcPort, "grpc-port to use")
+	flag.StringVar(&o.ListenMetricsURLs, "listen-metric-urls", o.ListenMetricsURLs, "listen-metric-urls configure etcd dedicated metrics URL endpoints")
 	flag.StringVar(&o.ClientUrls, "client-urls", o.ClientUrls, "client-urls to use for normal operation")
 	flag.StringVar(&o.QuarantineClientUrls, "quarantine-client-urls", o.QuarantineClientUrls, "client-urls to use when etcd should be quarantined e.g. when offline")
 	flag.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "name of cluster")
@@ -143,6 +144,9 @@ type EtcdManagerOptions struct {
 
 	// We have an explicit option for insecure configuration for etcd
 	EtcdInsecure bool
+
+	// ListenMetricsURLs allows configuration of the special etcd metrics urls
+	ListenMetricsURLs string
 }
 
 // InitDefaults populates the default flag values
@@ -383,7 +387,8 @@ func RunEtcdManager(o *EtcdManagerOptions) error {
 		glog.Fatalf("error performing scan for legacy data: %v", err)
 	}
 
-	etcdServer, err := etcd.NewEtcdServer(o.DataDir, o.ClusterName, o.ListenAddress, etcdNodeInfo, peerServer, dnsProvider, etcdClientsCA, etcdPeersCA)
+	listenMetricsURLs := expandUrls(o.ListenMetricsURLs, o.Address, name)
+	etcdServer, err := etcd.NewEtcdServer(o.DataDir, o.ClusterName, o.ListenAddress, listenMetricsURLs, etcdNodeInfo, peerServer, dnsProvider, etcdClientsCA, etcdPeersCA)
 	if err != nil {
 		return fmt.Errorf("error initializing etcd server: %v", err)
 	}

--- a/pkg/etcd/etcdprocess.go
+++ b/pkg/etcd/etcdprocess.go
@@ -76,6 +76,9 @@ type etcdProcess struct {
 
 	// ListenAddress is the address we bind to
 	ListenAddress string
+
+	// ListenMetricsURLs is the set of urls we should listen for metrics on
+	ListenMetricsURLs []string
 }
 
 func (p *etcdProcess) ExitState() (error, *os.ProcessState) {
@@ -188,6 +191,11 @@ func (p *etcdProcess) Start() error {
 	env["ETCD_LISTEN_CLIENT_URLS"] = strings.Join(changeHost(clientUrls, p.ListenAddress), ",")
 	env["ETCD_ADVERTISE_CLIENT_URLS"] = strings.Join(clientUrls, ",")
 	env["ETCD_INITIAL_ADVERTISE_PEER_URLS"] = strings.Join(me.PeerUrls, ",")
+
+	// This is only supported in 3.3 and later, but by using an env var it simply won't be picked up
+	if len(p.ListenMetricsURLs) != 0 {
+		env["ETCD_LISTEN_METRICS_URLS"] = strings.Join(p.ListenMetricsURLs, ",")
+	}
 
 	if p.CreateNewCluster {
 		env["ETCD_INITIAL_CLUSTER_STATE"] = "new"

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -44,6 +44,8 @@ type TestHarnessNode struct {
 	etcdController *controller.EtcdController
 
 	etcdClientTLSConfig *tls.Config
+
+	ListenMetricsURLs []string
 }
 
 func (n *TestHarnessNode) Init() error {
@@ -75,6 +77,8 @@ func (n *TestHarnessNode) Init() error {
 	} else {
 		n.ClientURL = "https://" + n.Address + ":4001"
 	}
+
+	n.ListenMetricsURLs = []string{"https://" + n.Address + ":8080"}
 
 	return nil
 }
@@ -192,7 +196,7 @@ func (n *TestHarnessNode) Run() {
 		etcdPeersCA = nil
 	}
 
-	etcdServer, err := etcd.NewEtcdServer(n.NodeDir, n.TestHarness.ClusterName, n.Address, me, peerServer, dnsProvider, etcdClientsCA, etcdPeersCA)
+	etcdServer, err := etcd.NewEtcdServer(n.NodeDir, n.TestHarness.ClusterName, n.Address, n.ListenMetricsURLs, me, peerServer, dnsProvider, etcdClientsCA, etcdPeersCA)
 	if err != nil {
 		t.Fatalf("error building EtcdServer: %v", err)
 	}


### PR DESCRIPTION
We map it through from the command line, and by passing it with an
env-var we can pass it to older versions (that will ignore it)