### PR TITLE
Use debug distroless image, so we have shell & tar

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,12 +49,12 @@ load(
 container_repositories()
 
 # Use a base image which includes ca-certificates (so we can talk to google / aws)
+# Note that we use the _debug_ version, so that we have a shell & tar
 container_pull(
-    name = "distroless_base",
-    digest = "sha256:e37cf3289c1332c5123cbf419a1657c8dad0811f2f8572433b668e13747718f8",
+    name = "distroless_base_debug",
+    digest = "sha256:f989df6099c5efb498021c7f01b74f484b46d2f5e1cdb862e508569d87569f2b",
     registry = "gcr.io",
     repository = "distroless/base",
-    tag = "e37cf3289c13",
 )
 
 #=============================================================================

--- a/images/BUILD
+++ b/images/BUILD
@@ -76,8 +76,19 @@ container_layer(
 )
 
 container_image(
+    name = "base",
+    base = "@distroless_base_debug//image",
+    # Put the most crucial symlinks in the more obvious place
+    # (they are currently in /busybox)
+    symlinks = {
+        "/bin/sh": "/busybox/busybox",
+        "/bin/tar": "/busybox/busybox",
+    },
+)
+
+container_image(
     name = "etcd-manager-base",
-    base = "@distroless_base//image",
+    base = "base",
     directory = "/opt",
     layers = [
         "etcd-2-2-1-layer",


### PR DESCRIPTION
Also put some symlinks in the more logical location, as the debug image puts the symlinks into /busybox