### PR TITLE
[DO-7442] Fix logic for Digital Ocean volume tag

### DIFF
--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -230,10 +230,10 @@ func RunEtcdManager(o *EtcdManagerOptions) error {
 				os.Exit(1)
 			}
 
-      volumeProvider = osVolumeProvider
+			volumeProvider = osVolumeProvider
 			discoveryProvider = osVolumeProvider
 
-    case "do":
+		case "do":
 			doVolumeProvider, err := do.NewDOVolumes(o.ClusterName, o.VolumeTags, o.NameTag)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/pkg/volumes/do/discovery.go
+++ b/pkg/volumes/do/discovery.go
@@ -32,40 +32,30 @@ func (a *DOVolumes) Poll() (map[string]discovery.Node, error) {
 
 	glog.V(2).Infof("Polling all DO Volumes")
 
-	var mytag = a.ClusterName + "-" + a.nameTag
-
 	allVolumes, err := a.findVolumes(false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover any volumes: %s", err)
 	}
 
-	// Iterate over every volume. By the time this is called, the instance should have the volume mounted
-	// When mounting a volume to an instance, the internal DOVolume object's Info's Description is set to the
-	// clustername_name tag
-	// which would either be k8s.io/etcd/main OR k8s.io/etcd/events.
-	// This name tag is passed as a command parameter to this container and the same is updated in DOVolumes
-	// Verify if the volume we are iterating matches the nameTag.
-	// This is a HACK until we update KOPS to utlize tags that we can compare here.
 	instanceToVolumeMap := make(map[string]*volumes.Volume)
 	for _, v := range allVolumes {
 		if v.AttachedTo != "" {
-			if mytag == v.Info.Description {
-
-				var myIP, _ = a.MyIP()
-
-				glog.V(2).Infof("Discovered a matching DO Volume for this instance with instanceid=%s volumename=%s nameTag=%s myIP=%s etcdName=%s", v.AttachedTo, v.ProviderID, a.nameTag, myIP, v.EtcdName)
-
-				instanceToVolumeMap[v.AttachedTo] = v
-
-				// We use the etcd node ID as the persistent identifier, because the data determines who we are
-				node := discovery.Node{
-					ID: v.EtcdName,
-				}
-
-				node.Endpoints = append(node.Endpoints, discovery.NodeEndpoint{IP: myIP})
-				nodes[node.ID] = node
-			}
+			instanceToVolumeMap[v.AttachedTo] = v
 		}
+	}
+
+	for _, volume := range instanceToVolumeMap {
+		var myIP, _ = a.MyIP()
+
+		glog.V(2).Infof("Discovered a matching DO Volume for this instance with instanceid=%s volumename=%s nameTag=%s myIP=%s etcdName=%s", volume.AttachedTo, volume.ProviderID, a.nameTag, myIP, volume.EtcdName)
+
+		// We use the etcd node ID as the persistent identifier, because the data determines who we are
+		node := discovery.Node{
+			ID: volume.EtcdName,
+		}
+
+		node.Endpoints = append(node.Endpoints, discovery.NodeEndpoint{IP: myIP})
+		nodes[node.ID] = node
 	}
 
 	return nodes, nil

--- a/pkg/volumes/do/volumes.go
+++ b/pkg/volumes/do/volumes.go
@@ -157,7 +157,10 @@ func (a *DOVolumes) findAllVolumes(filterByRegion bool) ([]*volumes.Volume, erro
 		tagFound := a.matchesDropletTags(&doVolume)
 
 		if tagFound {
-			myvolumes = a.appendMatchedVolume(&doVolume)
+			vol := a.appendMatchedVolume(&doVolume)
+			if vol != nil {
+				myvolumes = append(myvolumes, vol)
+			}
 		}
 	}
 
@@ -187,7 +190,10 @@ func (a *DOVolumes) findVolumes(filterByRegion bool) ([]*volumes.Volume, error) 
 		tagFound := a.matchesTags(&doVolume)
 
 		if tagFound {
-			myvolumes = a.appendMatchedVolume(&doVolume)
+			vol := a.appendMatchedVolume(&doVolume)
+			if vol != nil {
+				myvolumes = append(myvolumes, vol)
+			}
 		}
 	}
 
@@ -196,11 +202,11 @@ func (a *DOVolumes) findVolumes(filterByRegion bool) ([]*volumes.Volume, error) 
 
 // check for nameTag if it is contained in the volume name (for etcd-main or etcd-events)
 // if the nameTag matches the volume (etcd-main or etcd-events) add them to the volume list.
-func (a *DOVolumes) appendMatchedVolume(doVolume *godo.Volume) []*volumes.Volume {
-	var myvolumes []*volumes.Volume
+func (a *DOVolumes) appendMatchedVolume(doVolume *godo.Volume) *volumes.Volume {
 
 	glog.V(2).Infof("Tag Matched for droplet name=%s and volume name=%s", a.dropletName, doVolume.Name)
 
+	var retvol *volumes.Volume = nil
 	var clusterKey string
 	if strings.Contains(doVolume.Name, "etcd-main") {
 		clusterKey = "main"
@@ -224,11 +230,10 @@ func (a *DOVolumes) appendMatchedVolume(doVolume *godo.Volume) []*volumes.Volume
 		}
 
 		glog.V(2).Infof("Found a matching nameTag=%s for cluster key=%s with etcd cluster name = %s; volume name = %s", a.nameTag, clusterKey, a.ClusterName, doVolume.Name)
-
-		myvolumes = append(myvolumes, vol)
+		retvol = vol
 	}
 
-	return myvolumes
+	return retvol
 }
 
 func (a *DOVolumes) matchesDropletTags(volume *godo.Volume) bool {

--- a/pkg/volumes/do/volumes.go
+++ b/pkg/volumes/do/volumes.go
@@ -321,9 +321,9 @@ func (a *DOVolumes) matchesTags(volume *godo.Volume) bool {
 	return len(a.matchTagKeys) == matchingTagCount
 }
 
-// Contains tells whether a contains x.
-func (a *DOVolumes) Contains(tags []string, x string) bool {
-	for _, n := range tags {
+// Contains tells whether dotags contains x.
+func (a *DOVolumes) Contains(dotags []string, x string) bool {
+	for _, n := range dotags {
 		if strings.ToUpper(x) == strings.ToUpper(n) {
 			return true
 		}

--- a/pkg/volumes/do/volumes.go
+++ b/pkg/volumes/do/volumes.go
@@ -72,7 +72,6 @@ type DOVolumes struct {
 	nameTag      string
 	matchTagKeys []string
 	matchTags    map[string]string
-	//kopsClusterName string
 	dropletTags []string
 }
 


### PR DESCRIPTION
This PR is related to the PR that's merged in KOPS (https://github.com/kubernetes/kops/pull/7566)

As part of this change, we have consistent volume tags and droplet tags that are used when bringing up the DO cluster. These tags are matched and accordingly the volumes and associated to the correct droplets.  This change should help in associating multi master nodes, previously DO only supported a single node master.

Once this change is merged, will update KOPS with the newer version of etcd-manager. Also will be sending another PR on KOPS side for protokube seed cluster changes.