### PR TITLE
travis: Test newer bazel versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ os:
 #  - osx
 
 env:
-  - BAZEL_VERSION=0.26.1
-  - BAZEL_VERSION=0.27.2
-  - BAZEL_VERSION=0.28.1
+  - BAZEL_VERSION=0.29.1
+  - BAZEL_VERSION=1.0.1
+  - BAZEL_VERSION=1.1.0
 
 before_install:
   - pwd


### PR DESCRIPTION
Some of these bazel versions were effectively obsolete; move testing
to the versions in more widespread use.