### PR TITLE
rename etcd-manager argument listen-metrics-url to match etcd's

### DIFF
--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -71,7 +71,7 @@ func main() {
 	flag.StringVar(&o.Address, "address", o.Address, "local address to use")
 	flag.StringVar(&o.PeerUrls, "peer-urls", o.PeerUrls, "peer-urls to use")
 	flag.IntVar(&o.GrpcPort, "grpc-port", o.GrpcPort, "grpc-port to use")
-	flag.StringVar(&o.ListenMetricsURLs, "listen-metric-urls", o.ListenMetricsURLs, "listen-metric-urls configure etcd dedicated metrics URL endpoints")
+	flag.StringVar(&o.ListenMetricsURLs, "listen-metrics-urls", o.ListenMetricsURLs, "listen-metrics-urls configure etcd dedicated metrics URL endpoints")
 	flag.StringVar(&o.ClientUrls, "client-urls", o.ClientUrls, "client-urls to use for normal operation")
 	flag.StringVar(&o.QuarantineClientUrls, "quarantine-client-urls", o.QuarantineClientUrls, "client-urls to use when etcd should be quarantined e.g. when offline")
 	flag.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "name of cluster")


### PR DESCRIPTION
etcd-manager added support for --listen-metric-urls as a pass-through argument for etcd, however there seems to be a typo - while the etcd argument uses listen-metric**s**-urls, etcd-manager's is missing an s.