### PR TITLE
Update bazel rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ push: push-etcd-manager push-etcd-dump push-etcd-backup
 
 .PHONY: gazelle
 gazelle:
-	bazel run //:gazelle
+	bazel run //:gazelle -- fix
 	git checkout -- vendor
 	rm -f vendor/github.com/coreos/etcd/cmd/etcd
 	#rm vendor/github.com/golang/protobuf/protoc-gen-go/testdata/multi/BUILD.bazel

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,19 +3,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 http_archive(
     name = "io_bazel_rules_go",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.20.1/rules_go-v0.20.1.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.1/rules_go-v0.20.1.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.20.2/rules_go-v0.20.2.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.2/rules_go-v0.20.2.tar.gz",
     ],
-    sha256 = "842ec0e6b4fbfdd3de6150b61af92901eeb73681fd4d185746644c338f51d4c0",
+    sha256 = "b9aa86ec08a292b97ec4591cf578e020b35f98e12173bbd4a921f84f583aebd9",
 )
 
 http_archive(
     name = "bazel_gazelle",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
     ],
-    sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
+    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
@@ -23,7 +23,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.13.3",
+    go_version = "1.13.4",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
@@ -34,9 +34,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "413bb1ec0895a8d3249a01edf24b82fd06af3c8633c9fb833a0cb1d4b234d46d",
-    strip_prefix = "rules_docker-0.12.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.12.0/rules_docker-v0.12.0.tar.gz"],
+    sha256 = "14ac30773fdb393ddec90e158c9ec7ebb3f8a4fd533ec2abbfd8789ad81a284b",
+    strip_prefix = "rules_docker-0.12.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.12.1/rules_docker-v0.12.1.tar.gz"],
 )
 
 load(

--- a/vendor/google.golang.org/grpc/internal/channelz/BUILD.bazel
+++ b/vendor/google.golang.org/grpc/internal/channelz/BUILD.bazel
@@ -18,6 +18,9 @@ go_library(
         "//vendor/google.golang.org/grpc/credentials:go_default_library",
         "//vendor/google.golang.org/grpc/grpclog:go_default_library",
     ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],

--- a/vendor/google.golang.org/grpc/internal/syscall/BUILD.bazel
+++ b/vendor/google.golang.org/grpc/internal/syscall/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//vendor/google.golang.org/grpc:__subpackages__"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/google.golang.org/grpc/grpclog:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
@@ -20,6 +21,9 @@ go_library(
             "//vendor/google.golang.org/grpc/grpclog:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/google.golang.org/grpc/grpclog:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
             "//vendor/google.golang.org/grpc/grpclog:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/BUILD.bazel
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/BUILD.bazel
@@ -23,6 +23,10 @@ go_library(
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+            "//vendor/k8s.io/kubernetes/pkg/util/file:go_default_library",
+            "//vendor/k8s.io/kubernetes/pkg/util/io:go_default_library",
             "//vendor/k8s.io/kubernetes/pkg/util/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
@@ -32,6 +36,9 @@ go_library(
             "//vendor/k8s.io/kubernetes/pkg/util/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/k8s.io/kubernetes/pkg/util/nsenter:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
             "//vendor/k8s.io/kubernetes/pkg/util/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [

--- a/vendor/k8s.io/kubernetes/pkg/util/nsenter/BUILD.bazel
+++ b/vendor/k8s.io/kubernetes/pkg/util/nsenter/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/github.com/golang/glog:go_default_library",
             "//vendor/k8s.io/utils/exec:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
@@ -22,6 +23,9 @@ go_library(
             "//vendor/k8s.io/utils/exec:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/k8s.io/utils/exec:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
             "//vendor/k8s.io/utils/exec:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [


### PR DESCRIPTION
Move to go 1.13.4, which has a http2 fix; we haven't seen it but it
seems worth picking up given our use of GRPC.