### PR TITLE
Fix error handling bug

### DIFF
--- a/pkg/etcdclient/localnode.go
+++ b/pkg/etcdclient/localnode.go
@@ -63,10 +63,11 @@ func (c *V3Client) LocalNodeInfo(ctx context.Context) (*LocalNodeInfo, error) {
 		if err != nil {
 			glog.Warningf("unable to get status from %q: %v", endpoint, err)
 			lastErr = err
+		} else {
+			return &LocalNodeInfo{
+				IsLeader: response.Header.MemberId == response.Leader,
+			}, nil
 		}
-		return &LocalNodeInfo{
-			IsLeader: response.Header.MemberId == response.Leader,
-		}, nil
 	}
 	return nil, lastErr
 }


### PR DESCRIPTION
We weren't correctly trying all endpoints; as detetced by staticcheck.

Not terribly likely to happen in practice, but not what was intended.