### PR TITLE
Adding etcd 3.4.3 into the layers for etcd-manager

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -72,3 +72,14 @@ gazelle(
     "etcd",
     "etcdctl",
 ]]
+
+[genrule(
+    name = "etcd-v3.4.3-linux-amd64_%s" % c,
+    srcs = ["@etcd_3_4_3_tar//file"],
+    outs = ["etcd-v3.4.3-linux-amd64/%s" % c],
+    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_4_3_tar//file) etcd-v3.4.3-linux-amd64/%s && mv etcd-v3.4.3-linux-amd64/%s \"$@\"" % (c, c),
+    visibility = ["//visibility:public"],
+) for c in [
+    "etcd",
+    "etcdctl",
+]]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,6 +105,12 @@ http_file(
     urls = ["https://github.com/coreos/etcd/releases/download/v3.3.13/etcd-v3.3.13-linux-amd64.tar.gz"],
 )
 
+http_file(
+    name = "etcd_3_4_3_tar",
+    sha256 = "6c642b723a86941b99753dff6c00b26d3b033209b15ee33325dc8e7f4cd68f07",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.4.3/etcd-v3.4.3-linux-amd64.tar.gz"],
+)
+
 #=============================================================================
 # Build etcd from source
 # This picks up a number of critical bug fixes, for example:

--- a/images/BUILD
+++ b/images/BUILD
@@ -75,6 +75,16 @@ container_layer(
     ],
 )
 
+# Layer for etcd 3.4.3, updated recommendation for k8s 1.17 and later
+container_layer(
+    name = "etcd-3-4-3-layer",
+    directory = "/opt/etcd-v3.4.3-linux-amd64/",
+    files = [
+        "//:etcd-v3.4.3-linux-amd64_etcdctl",
+        "//:etcd-v3.4.3-linux-amd64_etcd",
+    ],
+)
+
 container_image(
     name = "etcd-manager-base",
     base = "@debian-hyperkube-base-amd64//image",
@@ -86,6 +96,7 @@ container_image(
         "etcd-3-2-24-layer",
         "etcd-3-3-10-layer",
         "etcd-3-3-13-layer",
+	"etcd-3-4-3-layer",
     ],
 )
 

--- a/pkg/etcdversions/mappings.go
+++ b/pkg/etcdversions/mappings.go
@@ -17,6 +17,7 @@ const (
 	Version_3_2_24 = "3.2.24"
 	Version_3_3_10 = "3.3.10"
 	Version_3_3_13 = "3.3.13"
+	Version_3_4_3  = "3.4.3"
 )
 
 var AllEtcdVersions = []string{
@@ -26,6 +27,7 @@ var AllEtcdVersions = []string{
 	Version_3_2_24,
 	Version_3_3_10,
 	Version_3_3_13,
+	Version_3_4_3,
 }
 
 func UpgradeInPlaceSupported(fromVersion, toVersion string) bool {
@@ -63,6 +65,12 @@ func UpgradeInPlaceSupported(fromVersion, toVersion string) bool {
 		if fromSemver.Minor == 3 && toSemver.Minor == 3 {
 			return true
 		}
+		if fromSemver.Minor == 3 && toSemver.Minor == 4 {
+			return true
+		}
+		if fromSemver.Minor == 4 && toSemver.Minor == 4 {
+			return true
+		}
 	}
 
 	return false
@@ -95,6 +103,8 @@ func EtcdVersionForAdoption(fromVersion string) string {
 		} else {
 			return Version_3_3_13
 		}
+	case "3.4":
+		return Version_3_4_3
 	default:
 		return ""
 	}
@@ -127,6 +137,8 @@ func EtcdVersionForRestore(fromVersion string) string {
 		} else {
 			return Version_3_3_13
 		}
+	case "3.4":
+		return Version_3_4_3
 	default:
 		return ""
 	}

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//:etcd-v3.3.10-linux-amd64_etcdctl",
         "//:etcd-v3.3.13-linux-amd64_etcd",
         "//:etcd-v3.3.13-linux-amd64_etcdctl",
+	"//:etcd-v3.4.3-linux-amd64_etcdctl",
     ],
     deps = [
         "//pkg/apis/etcd:go_default_library",


### PR DESCRIPTION
Addresses #249 by adding etcd 3.4.3 for kubernetes version 1.17

Signed-off-by: mmerrill3 <michael.merrill@vonage.com>