### PR TITLE
Allow overwriting etcd configs with env variables.

### DIFF
--- a/pkg/etcd/etcdprocess.go
+++ b/pkg/etcd/etcdprocess.go
@@ -243,6 +243,16 @@ func (p *etcdProcess) Start() error {
 		klog.Warningf("using insecure configuration for etcd clients")
 	}
 
+	// This should be the last step before setting the env vars for the
+	// command so that any param can be overwritten.
+	for _, e := range os.Environ() {
+		envPair := strings.SplitN(e, "=", 2)
+		if strings.HasPrefix(envPair[0], "ETCD_") {
+			klog.Infof("Overwriting etcd setting %s with value %s", envPair[0], envPair[1])
+			env[envPair[0]] = envPair[1]
+		}
+	}
+
 	for k, v := range env {
 		c.Env = append(c.Env, k+"="+v)
 	}

--- a/pkg/etcd/etcdprocess.go
+++ b/pkg/etcd/etcdprocess.go
@@ -246,8 +246,8 @@ func (p *etcdProcess) Start() error {
 	// This should be the last step before setting the env vars for the
 	// command so that any param can be overwritten.
 	for _, e := range os.Environ() {
-		envPair := strings.SplitN(e, "=", 2)
-		if strings.HasPrefix(envPair[0], "ETCD_") {
+		if strings.HasPrefix(e, "ETCD_") {
+			envPair := strings.SplitN(e, "=", 2)
 			klog.Infof("Overwriting etcd setting %s with value %s", envPair[0], envPair[1])
 			env[envPair[0]] = envPair[1]
 		}


### PR DESCRIPTION
This allows a user to overwrite etcd setting with env vars.

There's no validation done to the user set overwrites.