### PR TITLE
Add support for etcd 3.3.17

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -74,6 +74,17 @@ gazelle(
 ]]
 
 [genrule(
+    name = "etcd-v3.3.17-linux-amd64_%s" % c,
+    srcs = ["@etcd_3_3_17_tar//file"],
+    outs = ["etcd-v3.3.17-linux-amd64/%s" % c],
+    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_3_17_tar//file) etcd-v3.3.17-linux-amd64/%s && mv etcd-v3.3.17-linux-amd64/%s \"$@\"" % (c, c),
+    visibility = ["//visibility:public"],
+) for c in [
+    "etcd",
+    "etcdctl",
+]]
+
+[genrule(
     name = "etcd-v3.4.3-linux-amd64_%s" % c,
     srcs = ["@etcd_3_4_3_tar//file"],
     outs = ["etcd-v3.4.3-linux-amd64/%s" % c],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,6 +106,12 @@ http_file(
 )
 
 http_file(
+    name = "etcd_3_3_17_tar",
+    sha256 = "8c1168a24d17a2d6772f8148ea35d4f3398c51f1e23db90c849d506adb387060",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.3.17/etcd-v3.3.17-linux-amd64.tar.gz"],
+)
+
+http_file(
     name = "etcd_3_4_3_tar",
     sha256 = "6c642b723a86941b99753dff6c00b26d3b033209b15ee33325dc8e7f4cd68f07",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.4.3/etcd-v3.4.3-linux-amd64.tar.gz"],

--- a/images/BUILD
+++ b/images/BUILD
@@ -75,6 +75,16 @@ container_layer(
     ],
 )
 
+# Layer for etcd 3.3.17, updated recommendation for k8s 1.16.3 and later
+container_layer(
+    name = "etcd-3-3-17-layer",
+    directory = "/opt/etcd-v3.3.17-linux-amd64/",
+    files = [
+        "//:etcd-v3.3.17-linux-amd64_etcdctl",
+        "//:etcd-v3.3.17-linux-amd64_etcd",
+    ],
+)
+
 # Layer for etcd 3.4.3, updated recommendation for k8s 1.17 and later
 container_layer(
     name = "etcd-3-4-3-layer",
@@ -96,6 +106,7 @@ container_image(
         "etcd-3-2-24-layer",
         "etcd-3-3-10-layer",
         "etcd-3-3-13-layer",
+        "etcd-3-3-17-layer",
         "etcd-3-4-3-layer",
     ],
 )

--- a/pkg/etcdversions/mappings.go
+++ b/pkg/etcdversions/mappings.go
@@ -17,6 +17,7 @@ const (
 	Version_3_2_24 = "3.2.24"
 	Version_3_3_10 = "3.3.10"
 	Version_3_3_13 = "3.3.13"
+	Version_3_3_17 = "3.3.17"
 	Version_3_4_3  = "3.4.3"
 )
 
@@ -27,6 +28,7 @@ var AllEtcdVersions = []string{
 	Version_3_2_24,
 	Version_3_3_10,
 	Version_3_3_13,
+	Version_3_3_17,
 	Version_3_4_3,
 }
 
@@ -100,8 +102,10 @@ func EtcdVersionForAdoption(fromVersion string) string {
 	case "3.3":
 		if fromSemver.Patch <= 10 {
 			return Version_3_3_10
-		} else {
+		} else if fromSemver.Patch <= 13 {
 			return Version_3_3_13
+		} else {
+			return Version_3_3_17
 		}
 	case "3.4":
 		return Version_3_4_3
@@ -134,8 +138,10 @@ func EtcdVersionForRestore(fromVersion string) string {
 	case "3.3":
 		if fromSemver.Patch <= 10 {
 			return Version_3_3_10
-		} else {
+		} else if fromSemver.Patch <= 13 {
 			return Version_3_3_13
+		} else {
+			return Version_3_3_17
 		}
 	case "3.4":
 		return Version_3_4_3

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -24,6 +24,8 @@ go_test(
         "//:etcd-v3.3.10-linux-amd64_etcdctl",
         "//:etcd-v3.3.13-linux-amd64_etcd",
         "//:etcd-v3.3.13-linux-amd64_etcdctl",
+        "//:etcd-v3.3.17-linux-amd64_etcd",
+        "//:etcd-v3.3.17-linux-amd64_etcdctl",
         "//:etcd-v3.4.3-linux-amd64_etcd",
         "//:etcd-v3.4.3-linux-amd64_etcdctl",
     ],


### PR DESCRIPTION
This is used by K8s 1.16: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#changed


Note: I'm having bazel issues running `make test` on the master branch so I haven't had a chance to confirm the tests pass with this PR.