### PR TITLE
Always renew certificates

### DIFF
--- a/pkg/pki/BUILD.bazel
+++ b/pkg/pki/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -17,4 +17,10 @@ go_library(
         "//vendor/k8s.io/client-go/util/keyutil:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["parse_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/pki/certutils.go
+++ b/pkg/pki/certutils.go
@@ -39,8 +39,6 @@ const (
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
 
 	rsaKeySize = 2048
-
-	duration365d = time.Hour * 24 * 365
 )
 
 // EncodeCertPEM returns PEM-endcoded certificate data
@@ -67,7 +65,7 @@ func NewPrivateKey() (*rsa.PrivateKey, error) {
 }
 
 // NewSignedCert creates a signed certificate using the given CA certificate and key
-func NewSignedCert(cfg *certutil.Config, key crypto.Signer, caCert *x509.Certificate, caKey crypto.Signer) (*x509.Certificate, error) {
+func NewSignedCert(cfg *certutil.Config, key crypto.Signer, caCert *x509.Certificate, caKey crypto.Signer, duration time.Duration) (*x509.Certificate, error) {
 	serial, err := cryptorand.Int(cryptorand.Reader, new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
 		return nil, err
@@ -88,7 +86,7 @@ func NewSignedCert(cfg *certutil.Config, key crypto.Signer, caCert *x509.Certifi
 		IPAddresses:  cfg.AltNames.IPs,
 		SerialNumber: serial,
 		NotBefore:    caCert.NotBefore,
-		NotAfter:     time.Now().Add(duration365d).UTC(),
+		NotAfter:     time.Now().Add(duration).UTC(),
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  cfg.Usages,
 	}

--- a/pkg/pki/parse_test.go
+++ b/pkg/pki/parse_test.go
@@ -1,0 +1,34 @@
+package pki
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseHumanDuration(t *testing.T) {
+	grid := []struct {
+		Value    string
+		Expected time.Duration
+	}{
+		{"10m", 10 * time.Minute},
+		{"24h", 24 * time.Hour},
+		{"1d", 24 * time.Hour},
+		{"10d", 10 * 24 * time.Hour},
+		{"365d", 365 * 24 * time.Hour},
+		{"1y", 365 * 24 * time.Hour},
+		{"10y", 10 * 365 * 24 * time.Hour},
+	}
+
+	for _, g := range grid {
+		g := g
+		t.Run(g.Value, func(t *testing.T) {
+			actual, err := ParseHumanDuration(g.Value)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != g.Expected {
+				t.Fatalf("unexpected value; expected=%v, actual=%v", g.Expected, actual)
+			}
+		})
+	}
+}

--- a/test/integration/upgradedowngrade_test.go
+++ b/test/integration/upgradedowngrade_test.go
@@ -139,7 +139,7 @@ func TestUpgradeDowngrade(t *testing.T) {
 						t.Fatalf("error reading test key after downgrade: %v", err)
 					}
 					if v != "worldv3" {
-						t.Fatalf("unexpected test key value after upgrade: %q", v)
+						t.Fatalf("unexpected test key value after downgrade: %q", v)
 					}
 
 					n1.AssertVersion(t, fromVersion)


### PR DESCRIPTION
We raise the minimum required time to 20 years, effectively ensuring
that we won't reuse certificates.

We also now issue them for 2 years, to allow for the longer time
horizons of LTS kubernetes support.

Both these values can be customized through env vars, the defaults
correspond to these env vars:

ETCD_MANAGER_CERT_DURATION=2y
ETCD_MANAGER_CERT_MIN_TIME_LEFT=20y