### PR TITLE
Bazel: update dependency

### DIFF
--- a/pkg/locking/BUILD.bazel
+++ b/pkg/locking/BUILD.bazel
@@ -19,4 +19,5 @@ go_test(
     name = "go_default_test",
     srcs = ["lock_test.go"],
     embed = [":go_default_library"],
+    deps = ["//vendor/k8s.io/klog:go_default_library"],
 )


### PR DESCRIPTION
I forgot to regenerate bazel last time (and bizarrely, the tests still
passed)