### PR TITLE
Remove old bazel versions from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ os:
 #  - osx
 
 env:
-  - BAZEL_VERSION=1.0.1
-  - BAZEL_VERSION=1.1.0
   - BAZEL_VERSION=1.2.1
-  - BAZEL_VERSION=2.0.0
+  - BAZEL_VERSION=2.2.0
 
 before_install:
   - pwd


### PR DESCRIPTION
Old bazel v1 versions are no longer compatible with latest rules-go.

Also update bazel v2 tests to test with our preferred version (2.2.0)