### PR TITLE
(Issue #331) Supporting etcd version 3.4.7 for k8s >= 1.19

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -94,3 +94,14 @@ gazelle(
     "etcd",
     "etcdctl",
 ]]
+
+[genrule(
+    name = "etcd-v3.4.7-linux-amd64_%s" % c,
+    srcs = ["@etcd_3_4_7_tar//file"],
+    outs = ["etcd-v3.4.7-linux-amd64/%s" % c],
+    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_4_7_tar//file) etcd-v3.4.7-linux-amd64/%s && mv etcd-v3.4.7-linux-amd64/%s \"$@\"" % (c, c),
+    visibility = ["//visibility:public"],
+) for c in [
+    "etcd",
+    "etcdctl",
+]]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,6 +120,12 @@ http_file(
     urls = ["https://github.com/coreos/etcd/releases/download/v3.4.3/etcd-v3.4.3-linux-amd64.tar.gz"],
 )
 
+http_file(
+    name = "etcd_3_4_7_tar",
+    sha256 = "4ad86e663b63feb4855e1f3a647e719d6d79cf6306410c52b7f280fa56f8eb6b",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.4.7/etcd-v3.4.7-linux-amd64.tar.gz"],
+)
+
 #=============================================================================
 # Build etcd from source
 # This picks up a number of critical bug fixes, for example:

--- a/images/BUILD
+++ b/images/BUILD
@@ -95,6 +95,16 @@ container_layer(
     ],
 )
 
+# Layer for etcd 3.4.7, updated recommendation for k8s 1.19 and later
+container_layer(
+    name = "etcd-3-4-7-layer",
+    directory = "/opt/etcd-v3.4.7-linux-amd64/",
+    files = [
+        "//:etcd-v3.4.7-linux-amd64_etcdctl",
+        "//:etcd-v3.4.7-linux-amd64_etcd",
+    ],
+)
+
 container_image(
     name = "etcd-manager-base",
     base = "@debian-hyperkube-base-amd64//image",
@@ -108,6 +118,7 @@ container_image(
         "etcd-3-3-13-layer",
         "etcd-3-3-17-layer",
         "etcd-3-4-3-layer",
+	"etcd-3-4-7-layer",
     ],
 )
 

--- a/pkg/etcdversions/mappings.go
+++ b/pkg/etcdversions/mappings.go
@@ -19,6 +19,7 @@ const (
 	Version_3_3_13 = "3.3.13"
 	Version_3_3_17 = "3.3.17"
 	Version_3_4_3  = "3.4.3"
+	Version_3_4_7  = "3.4.7"
 )
 
 var AllEtcdVersions = []string{
@@ -30,6 +31,7 @@ var AllEtcdVersions = []string{
 	Version_3_3_13,
 	Version_3_3_17,
 	Version_3_4_3,
+	Version_3_4_7,
 }
 
 func UpgradeInPlaceSupported(fromVersion, toVersion string) bool {
@@ -108,7 +110,11 @@ func EtcdVersionForAdoption(fromVersion string) string {
 			return Version_3_3_17
 		}
 	case "3.4":
-		return Version_3_4_3
+		if fromSemver.Patch <= 18 {
+			return Version_3_4_3
+		} else {
+			return Version_3_4_7
+		}
 	default:
 		return ""
 	}
@@ -144,7 +150,11 @@ func EtcdVersionForRestore(fromVersion string) string {
 			return Version_3_3_17
 		}
 	case "3.4":
-		return Version_3_4_3
+		if fromSemver.Patch <= 18 {
+                        return Version_3_4_3
+                } else {
+			return Version_3_4_7
+		}
 	default:
 		return ""
 	}

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -28,6 +28,8 @@ go_test(
         "//:etcd-v3.3.17-linux-amd64_etcdctl",
         "//:etcd-v3.4.3-linux-amd64_etcd",
         "//:etcd-v3.4.3-linux-amd64_etcdctl",
+	"//:etcd-v3.4.7-linux-amd64_etcd",
+        "//:etcd-v3.4.7-linux-amd64_etcdctl",
     ],
     deps = [
         "//pkg/apis/etcd:go_default_library",


### PR DESCRIPTION
Signed-off-by: mmerrill3 <michael.merrill@vonage.com>

Issue #331 Supporting etcd version 3.4.7 for k8s versions greater than or equal to 1.19