### PR TITLE
Support for ARM64

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,101 +7,35 @@ gazelle(
     prefix = "kope.io/etcd-manager",
 )
 
-[genrule(
-    name = "etcd-v2.2.1-linux-amd64_%s" % c,
-    srcs = ["@etcd_2_2_1_tar//file"],
-    outs = ["etcd-v2.2.1-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_2_2_1_tar//file) etcd-v2.2.1-linux-amd64/%s && mv etcd-v2.2.1-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
+load("//images:etcd.bzl", "supported_etcd_arch_and_version")
 
-[genrule(
-    name = "etcd-v3.1.12-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_1_12_tar//file"],
-    outs = ["etcd-v3.1.12-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_1_12_tar//file) etcd-v3.1.12-linux-amd64/%s && mv etcd-v3.1.12-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.2.18-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_2_18_tar//file"],
-    outs = ["etcd-v3.2.18-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_2_18_tar//file) etcd-v3.2.18-linux-amd64/%s && mv etcd-v3.2.18-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.2.24-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_2_24_tar//file"],
-    outs = ["etcd-v3.2.24-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_2_24_tar//file) etcd-v3.2.24-linux-amd64/%s && mv etcd-v3.2.24-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.3.10-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_3_10_tar//file"],
-    outs = ["etcd-v3.3.10-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_3_10_tar//file) etcd-v3.3.10-linux-amd64/%s && mv etcd-v3.3.10-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.3.13-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_3_13_tar//file"],
-    outs = ["etcd-v3.3.13-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_3_13_tar//file) etcd-v3.3.13-linux-amd64/%s && mv etcd-v3.3.13-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.3.17-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_3_17_tar//file"],
-    outs = ["etcd-v3.3.17-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_3_17_tar//file) etcd-v3.3.17-linux-amd64/%s && mv etcd-v3.3.17-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.4.3-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_4_3_tar//file"],
-    outs = ["etcd-v3.4.3-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_4_3_tar//file) etcd-v3.4.3-linux-amd64/%s && mv etcd-v3.4.3-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
-
-[genrule(
-    name = "etcd-v3.4.13-linux-amd64_%s" % c,
-    srcs = ["@etcd_3_4_13_tar//file"],
-    outs = ["etcd-v3.4.13-linux-amd64/%s" % c],
-    cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_3_4_13_tar//file) etcd-v3.4.13-linux-amd64/%s && mv etcd-v3.4.13-linux-amd64/%s \"$@\"" % (c, c),
-    visibility = ["//visibility:public"],
-) for c in [
-    "etcd",
-    "etcdctl",
-]]
+[
+    genrule(
+        name = "etcd-v{version}-linux-{arch}_{bin}".format(
+            version = version,
+            arch = arch,
+            bin = bin,
+        ),
+        srcs = ["@etcd_{version}_{arch}_tar//file".format(
+            version = version,
+            arch = arch,
+            bin = bin,
+        )],
+        outs = ["etcd-v{version}-linux-{arch}/{bin}".format(
+            version = version,
+            arch = arch,
+            bin = bin,
+        )],
+        cmd = "tar -x -z --no-same-owner -f ./$(location @etcd_{version}_{arch}_tar//file) etcd-v{version}-linux-{arch}/{bin} && mv etcd-v{version}-linux-{arch}/{bin} \"$@\"".format(
+            version = version,
+            arch = arch,
+            bin = bin,
+        ),
+        visibility = ["//visibility:public"],
+    )
+    for (arch, version) in supported_etcd_arch_and_version()
+    for (bin) in [
+        "etcd",
+        "etcdctl",
+    ]
+]

--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,18 @@ goimports:
 
 .PHONY: push-etcd-manager
 push-etcd-manager:
-	bazel run ${BAZEL_FLAGS} //images:push-etcd-manager
+	bazel run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:push-etcd-manager
+	bazel run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //images:push-etcd-manager
 
 .PHONY: push-etcd-dump
 push-etcd-dump:
-	bazel run ${BAZEL_FLAGS} //images:push-etcd-dump
+	bazel run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:push-etcd-dump
+	bazel run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //images:push-etcd-dump
 
 .PHONY: push-etcd-backup
 push-etcd-backup:
-	bazel run ${BAZEL_FLAGS} //images:push-etcd-backup
+	bazel run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:push-etcd-backup
+	bazel run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //images:push-etcd-backup
 
 .PHONY: push
 push: push-etcd-manager push-etcd-dump push-etcd-backup

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,9 +60,10 @@ load(
 container_pull(
     name = "debian-base-amd64",
     architecture = "amd64",
-    digest = "sha256:30a33eaa75d591bd8a5ec1caee5259f79158c574615c8e06142a0f2ab2fec7cc",
-    registry = "l.gcr.io/google",
-    repository = "debian10",
+    digest = "sha256:dc06e242160076b72bd75135fb3dd0a9e91f386b2d812ec10cbf9e65864c755d",
+    registry = "k8s.gcr.io/build-image",
+    repository = "debian-base-amd64",
+    tag = "v2.1.3",  # ignored, but kept here for documentation
 )
 
 #=============================================================================

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,9 +34,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "dc97fccceacd4c6be14e800b2a00693d5e8d07f69ee187babfd04a80a9f8e250",
-    strip_prefix = "rules_docker-0.14.1",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.1/rules_docker-v0.14.1.tar.gz"],
+    sha256 = "14ac30773fdb393ddec90e158c9ec7ebb3f8a4fd533ec2abbfd8789ad81a284b",
+    strip_prefix = "rules_docker-0.12.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.12.1/rules_docker-v0.12.1.tar.gz"],
 )
 
 load(
@@ -51,6 +51,7 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 container_deps()
 
 # Note: We can't (easily) use distroless because we need: fsck, blkid, mount, others? to mount disks
+# We also have to use debian-hyperkube-base because we need nsenter / fsck
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",
@@ -58,12 +59,12 @@ load(
 )
 
 container_pull(
-    name = "debian-base-amd64",
+    name = "debian-hyperkube-base-amd64",
     architecture = "amd64",
-    digest = "sha256:dc06e242160076b72bd75135fb3dd0a9e91f386b2d812ec10cbf9e65864c755d",
-    registry = "k8s.gcr.io/build-image",
-    repository = "debian-base-amd64",
-    tag = "v2.1.3",  # ignored, but kept here for documentation
+    digest = "sha256:5d4ea2fb5fbe9a9a9da74f67cf2faefc881968bc39f2ac5d62d9167e575812a1",
+    registry = "k8s.gcr.io",
+    repository = "debian-hyperkube-base",
+    tag = "0.12.1",  # ignored, but kept here for documentation
 )
 
 #=============================================================================

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -185,3 +185,21 @@ http_file(
     sha256 = "1934ebb9f9f6501f706111b78e5e321a7ff8d7792d3d96a76e2d01874e42a300",
     urls = ["https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-arm64.tar.gz"],
 )
+
+#=============================================================================
+# Build etcd from source
+# This picks up a number of critical bug fixes, for example:
+#  * Caching of /etc/hosts https://github.com/golang/go/issues/13340
+#  * General GC etc improvements
+#  * Misc security fixes that are not backported
+
+# Download via HTTP
+go_repository(
+    name = "etcd_v2_2_1_source",
+    urls = ["https://github.com/etcd-io/etcd/archive/v2.2.1.tar.gz"],
+    sha256 = "1c0ce63812ef951f79c0a544c91f9f1ba3c6b50cb3e8197de555732454864d05",
+    importpath = "github.com/coreos/etcd",
+    strip_prefix = "etcd-2.2.1/",
+    build_external = "vendored",
+    build_file_proto_mode = "disable_global",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,19 +2,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "7b9bbe3ea1fccb46dcfa6c3f3e29ba7ec740d8733370e21cdc8937467b4a4349",
+    sha256 = "d9d71a5fdfcf5f5326f1ffc4bcaea6519cb4fcfe0aaee6ae68c7440ee8b46bc8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.4/rules_go-v0.22.4.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.4/rules_go-v0.22.4.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.7/rules_go-v0.22.7.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.7/rules_go-v0.22.7.tar.gz",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "d8c45ee70ec39a57e7a05e5027c32b1576cc7f16d9dd37135b0eddde45cf1b10",
+    sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.20.0/bazel-gazelle-v0.20.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.20.0/bazel-gazelle-v0.20.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
     ],
 )
 
@@ -23,7 +23,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.13.10",
+    go_version = "1.14.5",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
@@ -34,9 +34,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "14ac30773fdb393ddec90e158c9ec7ebb3f8a4fd533ec2abbfd8789ad81a284b",
-    strip_prefix = "rules_docker-0.12.1",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.12.1/rules_docker-v0.12.1.tar.gz"],
+    sha256 = "6287241e033d247e9da5ff705dd6ef526bac39ae82f3d17de1b69f8cb313f9cd",
+    strip_prefix = "rules_docker-0.14.3",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.3/rules_docker-v0.14.3.tar.gz"],
 )
 
 load(
@@ -184,22 +184,4 @@ http_file(
     name = "etcd_3.4.13_arm64_tar",
     sha256 = "1934ebb9f9f6501f706111b78e5e321a7ff8d7792d3d96a76e2d01874e42a300",
     urls = ["https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-arm64.tar.gz"],
-)
-
-#=============================================================================
-# Build etcd from source
-# This picks up a number of critical bug fixes, for example:
-#  * Caching of /etc/hosts https://github.com/golang/go/issues/13340
-#  * General GC etc improvements
-#  * Misc security fixes that are not backported
-
-# Download via HTTP
-go_repository(
-    name = "etcd_v2_2_1_source",
-    urls = ["https://github.com/etcd-io/etcd/archive/v2.2.1.tar.gz"],
-    sha256 = "1c0ce63812ef951f79c0a544c91f9f1ba3c6b50cb3e8197de555732454864d05",
-    importpath = "github.com/coreos/etcd",
-    strip_prefix = "etcd-2.2.1/",
-    build_external = "vendored",
-    build_file_proto_mode = "disable_global",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,63 +67,123 @@ container_pull(
     tag = "0.12.1",  # ignored, but kept here for documentation
 )
 
+container_pull(
+    name = "debian-hyperkube-base-arm64",
+    architecture = "arm64",
+    digest = "sha256:78eeb1a31eef7c16f954444d64636d939d89307e752964ad6d9d06966c722da3",
+    registry = "k8s.gcr.io",
+    repository = "debian-hyperkube-base",
+    tag = "0.12.1",  # ignored, but kept here for documentation
+)
+
 #=============================================================================
 # etcd rules
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-http_file(
-    name = "etcd_2_2_1_tar",
-    sha256 = "59f7985c81b6bc551246c165c2fd83e33a063875e4e0c61920b1d90a4910f462",
-    urls = ["https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz"],
-)
+# We build etcd 2.2 from source, because the released version has some critical problems,
+# particularly visible around caching of /etc/hosts
+#http_file(
+#    name = "etcd_2.2.1_tar",
+#    sha256 = "59f7985c81b6bc551246c165c2fd83e33a063875e4e0c61920b1d90a4910f462",
+#    urls = ["https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz"],
+#)
 
 http_file(
-    name = "etcd_3_1_12_tar",
+    name = "etcd_3.1.12_amd64_tar",
     sha256 = "4b22184bef1bba8b4908b14bae6af4a6d33ec2b91e4f7a240780e07fa43f2111",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.1.12/etcd-v3.1.12-linux-amd64.tar.gz"],
 )
 
+# 3.1.12 was not released for arm64
+#http_file(
+#    name = "etcd_3.1.12_arm64_tar",
+#    sha256 = "4b22184bef1bba8b4908b14bae6af4a6d33ec2b91e4f7a240780e07fa43f2123",
+#    urls = ["https://github.com/coreos/etcd/releases/download/v3.1.12/etcd-v3.1.12-linux-arm64.tar.gz"],
+#)
+
 http_file(
-    name = "etcd_3_2_18_tar",
+    name = "etcd_3.2.18_amd64_tar",
     sha256 = "b729db0732448064271ea6fdcb901773c4fe917763ca07776f22d0e5e0bd4097",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.2.18/etcd-v3.2.18-linux-amd64.tar.gz"],
 )
 
 http_file(
-    name = "etcd_3_2_24_tar",
+    name = "etcd_3.2.18_arm64_tar",
+    sha256 = "085c13764af02ca2762cbacade374583a532d4f75a7b996a62f67f8f044641e6",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.2.18/etcd-v3.2.18-linux-arm64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.2.24_amd64_tar",
     sha256 = "947849dbcfa13927c81236fb76a7c01d587bbab42ab1e807184cd91b026ebed7",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.2.24/etcd-v3.2.24-linux-amd64.tar.gz"],
 )
 
 http_file(
-    name = "etcd_3_3_10_tar",
+    name = "etcd_3.2.24_arm64_tar",
+    sha256 = "7d3db622fb8d22a669a9351e1002ed2a7a776004a4a35888734bf39323889390",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.2.24/etcd-v3.2.24-linux-arm64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.3.10_amd64_tar",
     sha256 = "1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz"],
 )
 
 http_file(
-    name = "etcd_3_3_13_tar",
+    name = "etcd_3.3.10_arm64_tar",
+    sha256 = "5ec97b0b872adce275b8130d19db314f7f2b803aeb24c4aae17a19e2d66853c4",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-arm64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.3.13_amd64_tar",
     sha256 = "2c2e2a9867c1c61697ea0d8c0f74c7e9f1b1cf53b75dff95ca3bc03feb19ea7e",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.3.13/etcd-v3.3.13-linux-amd64.tar.gz"],
 )
 
 http_file(
-    name = "etcd_3_3_17_tar",
+    name = "etcd_3.3.13_arm64_tar",
+    sha256 = "ff76e534db8378f112b48c445944069fc9923bef04dae4d66e36801da13cc8a1",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.3.13/etcd-v3.3.13-linux-arm64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.3.17_amd64_tar",
     sha256 = "8c1168a24d17a2d6772f8148ea35d4f3398c51f1e23db90c849d506adb387060",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.3.17/etcd-v3.3.17-linux-amd64.tar.gz"],
 )
 
 http_file(
-    name = "etcd_3_4_3_tar",
+    name = "etcd_3.3.17_arm64_tar",
+    sha256 = "0ea20dfbf3085f584f788287fd398979d0f1271549be6497d81ec635b9b4c121",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.3.17/etcd-v3.3.17-linux-arm64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.4.3_amd64_tar",
     sha256 = "6c642b723a86941b99753dff6c00b26d3b033209b15ee33325dc8e7f4cd68f07",
     urls = ["https://github.com/coreos/etcd/releases/download/v3.4.3/etcd-v3.4.3-linux-amd64.tar.gz"],
 )
 
 http_file(
-    name = "etcd_3_4_13_tar",
+    name = "etcd_3.4.3_arm64_tar",
+    sha256 = "01bd849ad99693600bd59db8d0e66ac64aac1e3801900665c31bd393972e3554",
+    urls = ["https://github.com/coreos/etcd/releases/download/v3.4.3/etcd-v3.4.3-linux-arm64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.4.13_amd64_tar",
     sha256 = "2ac029e47bab752dacdb7b30032f230f49e2f457cbc32e8f555c2210bb5ff107",
     urls = ["https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.4.13_arm64_tar",
+    sha256 = "1934ebb9f9f6501f706111b78e5e321a7ff8d7792d3d96a76e2d01874e42a300",
+    urls = ["https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-arm64.tar.gz"],
 )
 
 #=============================================================================

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,7 +61,7 @@ container_pull(
     name = "debian-base-amd64",
     architecture = "amd64",
     digest = "sha256:30a33eaa75d591bd8a5ec1caee5259f79158c574615c8e06142a0f2ab2fec7cc",
-    registry = "gcr.io/cloud-marketplace-containers/google",
+    registry = "l.gcr.io/google",
     repository = "debian10",
 )
 

--- a/images/BUILD
+++ b/images/BUILD
@@ -107,11 +107,11 @@ container_push(
     format = "Docker",
     image = ":etcd-manager",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = select({
-        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager-amd64",
-        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager-arm64",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager",
+    tag = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_TAG}-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_TAG}-arm64",
     }),
-    tag = "{STABLE_DOCKER_TAG}",
 )
 
 container_image(
@@ -132,11 +132,11 @@ container_push(
     format = "Docker",
     image = ":etcd-dump",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = select({
-        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump-amd64",
-        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump-arm64",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump",
+    tag = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_TAG}-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_TAG}-arm64",
     }),
-    tag = "{STABLE_DOCKER_TAG}",
 )
 
 container_image(
@@ -158,9 +158,9 @@ container_push(
     format = "Docker",
     image = ":etcd-backup",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = select({
-        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup-amd64",
-        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup-arm64",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup",
+    tag = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_TAG}-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_TAG}-arm64",
     }),
-    tag = "{STABLE_DOCKER_TAG}",
 )

--- a/images/BUILD
+++ b/images/BUILD
@@ -81,6 +81,10 @@ container_image(
     }),
     base = "etcd-manager-base",
     entrypoint = ["/etcd-manager"],
+    env = select({
+        "@io_bazel_rules_go//go/platform:amd64": {},
+        "@io_bazel_rules_go//go/platform:arm64": {"ETCD_UNSUPPORTED_ARCH": "arm64"},
+    }),
     files = [
         "//cmd/etcd-manager",
         "//cmd/etcd-manager-ctl",

--- a/images/BUILD
+++ b/images/BUILD
@@ -109,9 +109,25 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 
 # Install deps because we need nsenter / fsck
+download_pkgs(
+    name = "required_pkgs",
+    image_tar = "@debian-base-amd64//image:image.tar",
+    packages = [
+        "mount",
+        "util-linux",
+    ],
+)
+
+install_pkgs(
+    name = "debian-base-with-req-pkgs-amd64",
+    image_tar = "@debian-base-amd64//image:image.tar",
+    installables_tar = ":required_pkgs.tar",
+    output_image_name = "debian-base-with-req-pkgs-amd64",
+)
+
 container_image(
     name = "etcd-manager-base",
-    base = "@debian-base-amd64//image",
+    base = ":debian-base-with-req-pkgs-amd64",
     directory = "/opt",
     layers = [
         "etcd-2-2-1-layer",

--- a/images/BUILD
+++ b/images/BUILD
@@ -7,16 +7,6 @@ load(
     "container_push",
 )
 
-# Layer for etcd 2.2.1, the version of etcd2 that was originally recommended
-container_layer(
-    name = "etcd-2.2.1-layer-amd64",
-    directory = "/opt/etcd-v2.2.1-linux-amd64/",
-    files = [
-        "@etcd_v2_2_1_source//:etcd",
-        "@etcd_v2_2_1_source//etcdctl",
-    ],
-)
-
 load("etcd.bzl", "supported_etcd_arch_and_version")
 
 # Layer for etcd 3.1.12, as used in k8s 1.10
@@ -62,22 +52,33 @@ container_image(
     directory = "/opt",
     layers = select({
         "@io_bazel_rules_go//go/platform:amd64": [
-            "etcd-2.2.1-layer-amd64",
             "etcd-3.1.12-layer-amd64",
             "etcd-3.2.18-layer-amd64",
             "etcd-3.2.24-layer-amd64",
             "etcd-3.3.10-layer-amd64",
             "etcd-3.3.13-layer-amd64",
             "etcd-3.3.17-layer-amd64",
+            "etcd-3.4.3-layer-amd64",
+            "etcd-3.4.13-layer-amd64",
         ],
-        "//conditions:default": [],
-    }) + [
-        "etcd-3.4.3-layer-arm64",
-    ],
+        "@io_bazel_rules_go//go/platform:arm64": [
+            "etcd-3.2.18-layer-arm64",
+            "etcd-3.2.24-layer-arm64",
+            "etcd-3.3.10-layer-arm64",
+            "etcd-3.3.13-layer-arm64",
+            "etcd-3.3.17-layer-arm64",
+            "etcd-3.4.3-layer-arm64",
+            "etcd-3.4.13-layer-arm64",
+        ],
+    }),
 )
 
 container_image(
     name = "etcd-manager",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:amd64": "amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "arm64",
+    }),
     base = "etcd-manager-base",
     entrypoint = ["/etcd-manager"],
     files = [
@@ -91,12 +92,19 @@ container_push(
     format = "Docker",
     image = ":etcd-manager",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager",
+    repository = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager-arm64",
+    }),
     tag = "{STABLE_DOCKER_TAG}",
 )
 
 container_image(
     name = "etcd-dump",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:amd64": "amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "arm64",
+    }),
     base = "etcd-manager-base",
     entrypoint = ["/etcd-dump"],
     files = [
@@ -109,12 +117,19 @@ container_push(
     format = "Docker",
     image = ":etcd-dump",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump",
+    repository = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-dump-arm64",
+    }),
     tag = "{STABLE_DOCKER_TAG}",
 )
 
 container_image(
     name = "etcd-backup",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:amd64": "amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "arm64",
+    }),
     base = "etcd-manager-base",
     entrypoint = ["/etcd-backup"],
     files = [
@@ -128,6 +143,9 @@ container_push(
     format = "Docker",
     image = ":etcd-backup",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup",
+    repository = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_IMAGE_PREFIX}etcd-backup-arm64",
+    }),
     tag = "{STABLE_DOCKER_TAG}",
 )

--- a/images/BUILD
+++ b/images/BUILD
@@ -7,9 +7,9 @@ load(
     "container_push",
 )
 
-# Layer for etcd 2.2.1, the version of etcd2 that was recommended
+# Layer for etcd 2.2.1, the version of etcd2 that was originally recommended
 container_layer(
-    name = "etcd-2-2-1-layer",
+    name = "etcd-2.2.1-layer-amd64",
     directory = "/opt/etcd-v2.2.1-linux-amd64/",
     files = [
         "@etcd_v2_2_1_source//:etcd",
@@ -17,108 +17,62 @@ container_layer(
     ],
 )
 
-#container_layer(
-#    name = "etcd-2-2-1-layer-upstream",
-#    directory = "/opt/",
-#    tars = [
-#        "@etcd_2_2_1_tar//file",
-#],
-#)
+load("etcd.bzl", "supported_etcd_arch_and_version")
 
 # Layer for etcd 3.1.12, as used in k8s 1.10
-container_layer(
-    name = "etcd-3-1-12-layer",
-    directory = "/opt/etcd-v3.1.12-linux-amd64/",
-    files = [
-        "//:etcd-v3.1.12-linux-amd64_etcdctl",
-        "//:etcd-v3.1.12-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.2.18, as originally used in k8s 1.11
-container_layer(
-    name = "etcd-3-2-18-layer",
-    directory = "/opt/etcd-v3.2.18-linux-amd64/",
-    files = [
-        "//:etcd-v3.2.18-linux-amd64_etcdctl",
-        "//:etcd-v3.2.18-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.2.24, updated recommendation for k8s 1.11 and later
-container_layer(
-    name = "etcd-3-2-24-layer",
-    directory = "/opt/etcd-v3.2.24-linux-amd64/",
-    files = [
-        "//:etcd-v3.2.24-linux-amd64_etcdctl",
-        "//:etcd-v3.2.24-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.3.10, updated recommendation for k8s 1.14 and later
-container_layer(
-    name = "etcd-3-3-10-layer",
-    directory = "/opt/etcd-v3.3.10-linux-amd64/",
-    files = [
-        "//:etcd-v3.3.10-linux-amd64_etcdctl",
-        "//:etcd-v3.3.10-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.3.13, updated recommendation for k8s 1.14 and later
-container_layer(
-    name = "etcd-3-3-13-layer",
-    directory = "/opt/etcd-v3.3.13-linux-amd64/",
-    files = [
-        "//:etcd-v3.3.13-linux-amd64_etcdctl",
-        "//:etcd-v3.3.13-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.3.17, updated recommendation for k8s 1.16.3 and later
-container_layer(
-    name = "etcd-3-3-17-layer",
-    directory = "/opt/etcd-v3.3.17-linux-amd64/",
-    files = [
-        "//:etcd-v3.3.17-linux-amd64_etcdctl",
-        "//:etcd-v3.3.17-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.4.3, updated recommendation for k8s 1.17 and later
-container_layer(
-    name = "etcd-3-4-3-layer",
-    directory = "/opt/etcd-v3.4.3-linux-amd64/",
-    files = [
-        "//:etcd-v3.4.3-linux-amd64_etcdctl",
-        "//:etcd-v3.4.3-linux-amd64_etcd",
-    ],
-)
-
 # Layer for etcd 3.4.13, updated recommendation for k8s 1.19 and later
-container_layer(
-    name = "etcd-3-4-13-layer",
-    directory = "/opt/etcd-v3.4.13-linux-amd64/",
-    files = [
-        "//:etcd-v3.4.13-linux-amd64_etcdctl",
-        "//:etcd-v3.4.13-linux-amd64_etcd",
-    ],
-)
+[
+    container_layer(
+        name = "etcd-{version}-layer-{arch}".format(
+            arch = arch,
+            version = version,
+        ),
+        directory = "/opt/etcd-v{version}-linux-{arch}/".format(
+            arch = arch,
+            version = version,
+        ),
+        files = [
+            "//:etcd-v{version}-linux-{arch}_etcdctl".format(
+                arch = arch,
+                version = version,
+            ),
+            "//:etcd-v{version}-linux-{arch}_etcd".format(
+                arch = arch,
+                version = version,
+            ),
+        ],
+    )
+    for (arch, version) in supported_etcd_arch_and_version()
+]
 
+# We build a base layer that includes all the versions of etcd we want to ship
+# On non-amd64 we exclude the older versions of etcd
 container_image(
     name = "etcd-manager-base",
-    base = "@debian-hyperkube-base-amd64//image",
+    base = select({
+        "@io_bazel_rules_go//go/platform:amd64": "@debian-hyperkube-base-amd64//image",
+        "@io_bazel_rules_go//go/platform:arm64": "@debian-hyperkube-base-arm64//image",
+    }),
     directory = "/opt",
-    layers = [
-        "etcd-2-2-1-layer",
-        "etcd-3-1-12-layer",
-        "etcd-3-2-18-layer",
-        "etcd-3-2-24-layer",
-        "etcd-3-3-10-layer",
-        "etcd-3-3-13-layer",
-        "etcd-3-3-17-layer",
-        "etcd-3-4-3-layer",
-        "etcd-3-4-13-layer",
+    layers = select({
+        "@io_bazel_rules_go//go/platform:amd64": [
+            "etcd-2.2.1-layer-amd64",
+            "etcd-3.1.12-layer-amd64",
+            "etcd-3.2.18-layer-amd64",
+            "etcd-3.2.24-layer-amd64",
+            "etcd-3.3.10-layer-amd64",
+            "etcd-3.3.13-layer-amd64",
+            "etcd-3.3.17-layer-amd64",
+        ],
+        "//conditions:default": [],
+    }) + [
+        "etcd-3.4.3-layer-arm64",
     ],
 )
 

--- a/images/BUILD
+++ b/images/BUILD
@@ -7,6 +7,16 @@ load(
     "container_push",
 )
 
+# Layer for etcd 2.2.1, the version of etcd2 that was originally recommended
+container_layer(
+    name = "etcd-2.2.1-layer-amd64",
+    directory = "/opt/etcd-v2.2.1-linux-amd64/",
+    files = [
+        "@etcd_v2_2_1_source//:etcd",
+        "@etcd_v2_2_1_source//etcdctl",
+    ],
+)
+
 load("etcd.bzl", "supported_etcd_arch_and_version")
 
 # Layer for etcd 3.1.12, as used in k8s 1.10
@@ -52,6 +62,7 @@ container_image(
     directory = "/opt",
     layers = select({
         "@io_bazel_rules_go//go/platform:amd64": [
+            "etcd-2.2.1-layer-amd64",
             "etcd-3.1.12-layer-amd64",
             "etcd-3.2.18-layer-amd64",
             "etcd-3.2.24-layer-amd64",

--- a/images/BUILD
+++ b/images/BUILD
@@ -105,29 +105,9 @@ container_layer(
     ],
 )
 
-load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
-load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-
-# Install deps because we need nsenter / fsck
-download_pkgs(
-    name = "required_pkgs",
-    image_tar = "@debian-base-amd64//image:image.tar",
-    packages = [
-        "mount",
-        "util-linux",
-    ],
-)
-
-install_pkgs(
-    name = "debian-base-with-req-pkgs-amd64",
-    image_tar = "@debian-base-amd64//image:image.tar",
-    installables_tar = ":required_pkgs.tar",
-    output_image_name = "debian-base-with-req-pkgs-amd64",
-)
-
 container_image(
     name = "etcd-manager-base",
-    base = ":debian-base-with-req-pkgs-amd64",
+    base = "@debian-hyperkube-base-amd64//image",
     directory = "/opt",
     layers = [
         "etcd-2-2-1-layer",

--- a/images/BUILD
+++ b/images/BUILD
@@ -108,6 +108,7 @@ container_layer(
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 
+# Install deps because we need nsenter / fsck
 container_image(
     name = "etcd-manager-base",
     base = "@debian-base-amd64//image",

--- a/images/etcd.bzl
+++ b/images/etcd.bzl
@@ -1,0 +1,11 @@
+# Returns the supported arch & versions of etcd
+# This avoids repeating the etcd versions in multiple places,
+# and also avoids problems such as 3.1.12 not being available on arm
+def supported_etcd_arch_and_version():
+  return [
+    [ "amd64", "3.1.12" ],
+  ] + [
+    (arch, version)
+      for arch in ["amd64", "arm64"]
+      for version in ["3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3","3.4.13"]
+  ]

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -12,8 +12,6 @@ go_test(
         "upgradedowngrade_test.go",
     ],
     data = [
-        "@etcd_v2_2_1_source//:etcd",
-        "@etcd_v2_2_1_source//etcdctl:etcdctl",
         "//:etcd-v3.1.12-linux-amd64_etcd",
         "//:etcd-v3.1.12-linux-amd64_etcdctl",
         "//:etcd-v3.2.18-linux-amd64_etcd",

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -12,6 +12,8 @@ go_test(
         "upgradedowngrade_test.go",
     ],
     data = [
+        "@etcd_v2_2_1_source//:etcd",
+        "@etcd_v2_2_1_source//etcdctl:etcdctl",
         "//:etcd-v3.1.12-linux-amd64_etcd",
         "//:etcd-v3.1.12-linux-amd64_etcdctl",
         "//:etcd-v3.2.18-linux-amd64_etcd",


### PR DESCRIPTION
Taking #315 a bit further.

The manifest part can be done in 2 ways separately:
1. Using `docker manifest ...`:
```bash
$ export DOCKER_CLI_EXPERIMENTAL=enabled
$ docker manifest create \
    kopeio/etcd-manager:docker \
    kopeio/etcd-manager-amd64:latest kopeio/etcd-manager-arm64:latest
$ docker manifest push --purge kopeio/etcd-manager:docker
```
2. Using `manifest-tool ...`:
```bash
$ manifest-tool push from-args \
    --platforms linux/amd64,linux/arm64 \
    --template kopeio/etcd-manager-ARCHVARIANT:latest \
    --target kopeio/etcd-manager:latest
```
