### PR TITLE
Adds support for using OS application credentials

### DIFF
--- a/pkg/volumes/openstack/config.go
+++ b/pkg/volumes/openstack/config.go
@@ -28,20 +28,23 @@ type BlockStorageOpts struct {
 
 type Config struct {
 	Global struct {
-		AuthURL          string `gcfg:"auth-url"`
-		Username         string
-		UserID           string `gcfg:"user-id"`
-		Password         string
-		TenantID         string `gcfg:"tenant-id"`
-		TenantName       string `gcfg:"tenant-name"`
-		TrustID          string `gcfg:"trust-id"`
-		DomainID         string `gcfg:"domain-id"`
-		DomainName       string `gcfg:"domain-name"`
-		TenantDomainID   string `gcfg:"tenant-domain-id"`
-		TenantDomainName string `gcfg:"tenant-domain-name"`
-		Region           string
-		CAFile           string `gcfg:"ca-file"`
-		Cloud            string `gcfg:"cloud,omitempty"`
+		AuthURL                     string `gcfg:"auth-url"`
+		Username                    string
+		UserID                      string `gcfg:"user-id"`
+		Password                    string
+		TenantID                    string `gcfg:"tenant-id"`
+		TenantName                  string `gcfg:"tenant-name"`
+		TrustID                     string `gcfg:"trust-id"`
+		DomainID                    string `gcfg:"domain-id"`
+		DomainName                  string `gcfg:"domain-name"`
+		TenantDomainID              string `gcfg:"tenant-domain-id"`
+		TenantDomainName            string `gcfg:"tenant-domain-name"`
+		Region                      string
+		CAFile                      string `gcfg:"ca-file"`
+		Cloud                       string `gcfg:"cloud,omitempty"`
+		ApplicationCredentialID     string `gcfg:"application-credential-id"`
+		ApplicationCredentialName   string `gcfg:"application-credential-name"`
+		ApplicationCredentialSecret string `gcfg:"application-credential-secret"`
 	}
 	BlockStorage BlockStorageOpts
 }

--- a/pkg/volumes/openstack/volumes.go
+++ b/pkg/volumes/openstack/volumes.go
@@ -141,15 +141,18 @@ func getCredential() (gophercloud.AuthOptions, string, bool, error) {
 	}
 
 	return gophercloud.AuthOptions{
-		IdentityEndpoint: cfg.Global.AuthURL,
-		Username:         cfg.Global.Username,
-		UserID:           cfg.Global.UserID,
-		Password:         cfg.Global.Password,
-		TenantID:         cfg.Global.TenantID,
-		TenantName:       cfg.Global.TenantName,
-		DomainID:         cfg.Global.DomainID,
-		DomainName:       cfg.Global.DomainName,
-		AllowReauth:      true,
+		IdentityEndpoint:            cfg.Global.AuthURL,
+		Username:                    cfg.Global.Username,
+		UserID:                      cfg.Global.UserID,
+		Password:                    cfg.Global.Password,
+		TenantID:                    cfg.Global.TenantID,
+		TenantName:                  cfg.Global.TenantName,
+		DomainID:                    cfg.Global.DomainID,
+		DomainName:                  cfg.Global.DomainName,
+		ApplicationCredentialID:     cfg.Global.ApplicationCredentialID,
+		ApplicationCredentialName:   cfg.Global.ApplicationCredentialName,
+		ApplicationCredentialSecret: cfg.Global.ApplicationCredentialSecret,
+		AllowReauth:                 true,
 	}, cfg.Global.Region, cfg.BlockStorage.IgnoreVolumeAZ, nil
 }
 


### PR DESCRIPTION
Application credentials allows you to export a purpose-specific set of
credentials for a user instead of exposing user login credentials.
Especially useful when using LDAP or similar for Openstack users.
Also lets you rotate credentials more easily since multiple application
credentials can be provisioned per user.