### PR TITLE
Fixes usage of OpenStack Swift reauthentication

### DIFF
--- a/vendor/k8s.io/kops/util/pkg/vfs/swiftfs.go
+++ b/vendor/k8s.io/kops/util/pkg/vfs/swiftfs.go
@@ -51,6 +51,8 @@ func NewSwiftClient() (*gophercloud.ServiceClient, error) {
 		return nil, err
 	}
 
+	authOption.AllowReauth = true
+
 	pc, err := openstack.NewClient(authOption.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error building openstack provider client: %v", err)


### PR DESCRIPTION
OpenStack features expiring tokens which requires a client to reauth.

This fix ensures etcd-manager can continue creating backups to Swift
when the token expiry time is hit.

Fixes https://github.com/kubernetes/kops/issues/9730