### PR TITLE
Switch to gcr.io/cloud-marketplace-containers/google/debian10 - Fix for #340 option 1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,10 +60,9 @@ load(
 container_pull(
     name = "debian-base-amd64",
     architecture = "amd64",
-    digest = "sha256:dc06e242160076b72bd75135fb3dd0a9e91f386b2d812ec10cbf9e65864c755d",
-    registry = "k8s.gcr.io/build-image",
-    repository = "debian-base-amd64",
-    tag = "v2.1.3",  # ignored, but kept here for documentation
+    digest = "sha256:30a33eaa75d591bd8a5ec1caee5259f79158c574615c8e06142a0f2ab2fec7cc",
+    registry = "l.gcr.io/google",
+    repository = "debian10",
 )
 
 #=============================================================================

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,7 +61,7 @@ container_pull(
     name = "debian-base-amd64",
     architecture = "amd64",
     digest = "sha256:30a33eaa75d591bd8a5ec1caee5259f79158c574615c8e06142a0f2ab2fec7cc",
-    registry = "l.gcr.io/google",
+    registry = "gcr.io/cloud-marketplace-containers/google",
     repository = "debian10",
 )
 

--- a/images/BUILD
+++ b/images/BUILD
@@ -109,25 +109,9 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 
 # Install deps because we need nsenter / fsck
-download_pkgs(
-    name = "required_pkgs",
-    image_tar = "@debian-base-amd64//image:image.tar",
-    packages = [
-        "mount",
-        "util-linux",
-    ],
-)
-
-install_pkgs(
-    name = "debian-base-with-req-pkgs-amd64",
-    image_tar = "@debian-base-amd64//image:image.tar",
-    installables_tar = ":required_pkgs.tar",
-    output_image_name = "debian-base-with-req-pkgs-amd64",
-)
-
 container_image(
     name = "etcd-manager-base",
-    base = ":debian-base-with-req-pkgs-amd64",
+    base = "@debian-base-amd64//image",
     directory = "/opt",
     layers = [
         "etcd-2-2-1-layer",

--- a/images/BUILD
+++ b/images/BUILD
@@ -108,7 +108,6 @@ container_layer(
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 
-# Install deps because we need nsenter / fsck
 container_image(
     name = "etcd-manager-base",
     base = "@debian-base-amd64//image",


### PR DESCRIPTION
Switch to using  gcr.io/cloud-marketplace-containers/google/debian10 as there is an issue installing additional packages with install_pkgs onto image k8s.gcr.io/build-image/debian-base-amd64. Testing installation with other base Debian images work with no issues, however I have not been able to isolate the issue with utilizing k8s.gcr.io/build-image/debian-base-amd64

l.gcr.io/google/debian10 already contains the required packages so no need to install anything.

Fixes an issue introduced in #340