### PR TITLE
feat(etcd-manager-ctl): use backupname to delete backup instead of timestamp

### DIFF
--- a/cmd/etcd-manager-ctl/main.go
+++ b/cmd/etcd-manager-ctl/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/golang/protobuf/proto"
 	"k8s.io/klog"
@@ -171,7 +170,7 @@ func runDeleteCommand(ctx context.Context, o *Options, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("syntax: delete-command <backupname>")
 	}
-	commandID := args[0]
+	backupName := args[0]
 
 	commandStore, err := GetCommandStore(o)
 	if err != nil {
@@ -185,7 +184,7 @@ func runDeleteCommand(ctx context.Context, o *Options, args []string) error {
 
 	for _, c := range commands {
 		data := c.Data()
-		if strconv.FormatInt(data.Timestamp, 10) == commandID {
+		if data.RestoreBackup.Backup == backupName {
 			err := commandStore.RemoveCommand(c)
 			if err != nil {
 				return fmt.Errorf("error deleting command: %v", err)

--- a/docs/restore-troubleshooting.md
+++ b/docs/restore-troubleshooting.md
@@ -50,3 +50,14 @@ Make sure to replace `[MASTER IP]` with the IP of the old master.
 
 Once you've removed the old master IPs from etcd, the kubernetes service endpoints should be automatically updated.
 The kubernetes service should be functional again now, and flannel should come up on new nodes.
+
+## Corrupted restore-backup command in storage
+
+Once a cluster is established and a leader is selected, the leader will read the
+`restore-backup` command from storage. If this is an invalid command -- for
+example, one that specifies a nonexistent backup -- it is possible to enter a
+state where `etcd-manager` will fail to start up, and eventually enter a
+`CrashLoopBackOff` state.
+
+You can fix this by manually deleting the command from storage. You can do this
+by removing the backup via `etcd-manager-ctl delete-backup <backupname>`.


### PR DESCRIPTION
    This commit refactors the `runDeleteCommand` function of
    `etcd-manager-ctl` to use the "backup name" instead of the "timestamp"
    attribute. More often than not, users are more likely to become familiar
    with the syntax of `etcd-manager-ctl restore-backup`, which uses the
    `backupname` attribute to identify the target backup to restore.

    By bringing the `delete-backup` subcommand in alignment with
    `restore-backup`, we improve the user experience of an operator in the
    process of restoring a cluster.