### PR TITLE
govet: Fix a log message

### DIFF
--- a/pkg/volumes/external/volumes.go
+++ b/pkg/volumes/external/volumes.go
@@ -162,7 +162,7 @@ func (a *ExternalVolumes) FindVolumes() ([]*volumes.Volume, error) {
 		}
 
 		if !stat.IsDir() {
-			klog.V(2).Infof("expected directory at %s, but was not a directory; skipping")
+			klog.V(2).Infof("expected directory at %s, but was not a directory; skipping", mntPath)
 			continue
 		}
 


### PR DESCRIPTION
Simple fix while I was seeing if the bazel vet support works yet (it doesn't, but it might when we update rules-go)