### PR TITLE
Fix build on case-insensitive file systems (MacOS)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -201,6 +201,7 @@ go_repository(
     importpath = "github.com/coreos/etcd",
     strip_prefix = "etcd-2.2.1/",
     build_external = "vendored",
+    build_file_name = "BUILD.bazel", # See https://github.com/bazelbuild/rules_go/issues/456
     build_file_proto_mode = "disable_global",
 )
 


### PR DESCRIPTION
Due to https://github.com/bazelbuild/rules_go/issues/456 , the build of etcd 2.2.1 did not work correctly on case-insensitive file systems, including MacOS.

etcd has a shell script named `build`, which bazel was treating as a `BUILD` file.  By setting bazel to only look for `BUILD.bazel` files, this is avoided.