### PR TITLE
Set AltNames on server certificates

### DIFF
--- a/pkg/etcd/pki.go
+++ b/pkg/etcd/pki.go
@@ -45,7 +45,10 @@ func (p *etcdProcess) createKeypairs(peersCA *pki.Keypair, clientsCA *pki.Keypai
 
 		certConfig := certutil.Config{
 			CommonName: me.Name,
-			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+			AltNames: certutil.AltNames{
+				DNSNames: []string{me.Name},
+			},
+			Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		}
 
 		if err := addAltNames(&certConfig, me.PeerUrls); err != nil {
@@ -81,7 +84,10 @@ func (p *etcdProcess) createKeypairs(peersCA *pki.Keypair, clientsCA *pki.Keypai
 		// See https://github.com/etcd-io/etcd/issues/9785
 		certConfig := certutil.Config{
 			CommonName: me.Name,
-			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+			AltNames: certutil.AltNames{
+				DNSNames: []string{me.Name},
+			},
+			Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		}
 
 		if err := addAltNames(&certConfig, me.ClientUrls); err != nil {

--- a/pkg/tlsconfig/options.go
+++ b/pkg/tlsconfig/options.go
@@ -62,9 +62,13 @@ func GRPCServerConfig(keypairs *pki.Keypairs, myPeerID string) (*tls.Config, err
 	caPool := x509.NewCertPool()
 	caPool.AddCert(ca.Certificate)
 
+	name := "etcd-manager-server-" + myPeerID
 	config := certutil.Config{
-		CommonName: "etcd-manager-server-" + myPeerID,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		CommonName: name,
+		AltNames: certutil.AltNames{
+			DNSNames: []string{name},
+		},
+		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 
 	keypair, err := keypairs.EnsureKeypair("etcd-manager-server-"+myPeerID, config, ca)


### PR DESCRIPTION
This should address the deprecation in go 1.15 of server certificates that only have a Common Name (CN).