### PR TITLE
Exclude gazelle from tools/deb-tools

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:proto disable_global
+# gazelle:exclude tools/deb-tools/
 gazelle(
     name = "gazelle",
     external = "vendored",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -201,7 +201,7 @@ go_repository(
     importpath = "github.com/coreos/etcd",
     strip_prefix = "etcd-2.2.1/",
     build_external = "vendored",
-    build_file_name = "BUILD.bazel", # See https://github.com/bazelbuild/rules_go/issues/456
+    build_file_name = "BUILD.bazel",  # See https://github.com/bazelbuild/rules_go/issues/456
     build_file_proto_mode = "disable_global",
 )
 


### PR DESCRIPTION
It has its own (separate) bazel configuration