### PR TITLE
Add more descriptions to wait loops

### DIFF
--- a/test/integration/harness/cluster.go
+++ b/test/integration/harness/cluster.go
@@ -181,7 +181,8 @@ func (h *TestHarness) WaitForHasLeader(nodes ...*TestHarnessNode) {
 
 func (h *TestHarness) WaitForVersion(timeout time.Duration, expectedVersion string, nodes ...*TestHarnessNode) {
 	for _, n := range nodes {
-		h.WaitFor(timeout, func() error {
+		description := fmt.Sprintf("wait for node %s to have version %q", n.Address, expectedVersion)
+		h.WaitFor(timeout, description, func() error {
 			client, err := n.NewClient()
 			if err != nil {
 				return fmt.Errorf("error building etcd client: %v", err)

--- a/test/integration/harness/etcd.go
+++ b/test/integration/harness/etcd.go
@@ -110,7 +110,7 @@ func (n *TestHarnessNode) WaitForListMembers(timeout time.Duration) {
 	}
 }
 
-func (h *TestHarness) WaitFor(timeout time.Duration, f func() error) {
+func (h *TestHarness) WaitFor(timeout time.Duration, description string, f func() error) {
 	t := h.T
 
 	deadline := time.Now().Add(timeout)
@@ -120,10 +120,13 @@ func (h *TestHarness) WaitFor(timeout time.Duration, f func() error) {
 			return
 		}
 
+		// We also log to klog, so that it appears in the test output.
 		if time.Now().After(deadline) {
-			t.Fatalf("time out waiting for condition: %v", err)
+			klog.Errorf("time out waiting for condition %q: %v", description, err)
+			t.Fatalf("time out waiting for condition %q: %v", description, err)
 		} else {
-			t.Logf("waiting for condition: %v", err)
+			klog.Infof("waiting for condition %q: %v", description, err)
+			t.Logf("waiting for condition %q: %v", description, err)
 		}
 
 		time.Sleep(time.Second)

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -289,7 +289,8 @@ func (n *TestHarnessNode) AssertVersion(t *testing.T, version string) {
 }
 
 func (n *TestHarnessNode) WaitForHealthy(timeout time.Duration) {
-	n.TestHarness.WaitFor(timeout, func() error {
+	description := fmt.Sprintf("wait for node %s to be healthy", n.Address)
+	n.TestHarness.WaitFor(timeout, description, func() error {
 		client, err := n.NewClient()
 		if err != nil {
 			return fmt.Errorf("error building etcd client: %v", err)
@@ -302,7 +303,8 @@ func (n *TestHarnessNode) WaitForHealthy(timeout time.Duration) {
 }
 
 func (n *TestHarnessNode) WaitForHasLeader(timeout time.Duration) {
-	n.TestHarness.WaitFor(timeout, func() error {
+	description := fmt.Sprintf("wait for node %s to have a leader", n.Address)
+	n.TestHarness.WaitFor(timeout, description, func() error {
 		client, err := n.NewClient()
 		if err != nil {
 			return fmt.Errorf("error building etcd client: %v", err)

--- a/test/integration/secure_transitions_test.go
+++ b/test/integration/secure_transitions_test.go
@@ -102,7 +102,8 @@ func TestEnableTLS(t *testing.T) {
 					h.WaitForHealthy(nodes[0])
 
 					for i, n := range nodes {
-						h.WaitFor(120*time.Second, func() error {
+						description := fmt.Sprintf("wait for node %s to restart and settle", n.Address)
+						h.WaitFor(120*time.Second, description, func() error {
 							members, err := n.ListMembers(ctx)
 							if err != nil {
 								return fmt.Errorf("error doing etcd ListMembers: %v", err)


### PR DESCRIPTION
This should make diagnostics of failed tests a little easier.