### PR TITLE
Handling timeouts from etcd client healthcheck

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -686,12 +686,19 @@ func (m *EtcdController) updateClusterState(ctx context.Context, peers []*peer) 
 			continue
 		}
 
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		etcdClient, err := etcdclient.NewClient(p.info.EtcdState.EtcdVersion, clientUrls, m.etcdClientTLSConfig)
+		cancel()
+
 		if err != nil {
 			klog.Warningf("unable to reach member %s: %v", p, err)
 			continue
 		}
+
+		ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
 		members, err := etcdClient.ListMembers(ctx)
+		cancel()
+
 		etcdclient.LoggedClose(etcdClient)
 		if err != nil {
 			klog.Warningf("unable to reach member for ListMembers %s: %v", p, err)

--- a/pkg/etcd/pki.go
+++ b/pkg/etcd/pki.go
@@ -147,7 +147,12 @@ func addAltNames(certConfig *certutil.Config, urls []string) error {
 	}
 
 	// We always self-sign for 127.0.0.1, so that we can always be reached by apiserver / debug clients
+	// sometimes it will be there already
+	for _, ip := range certConfig.AltNames.IPs {
+		if ip.String() == "127.0.0.1" {
+			return nil
+		}
+	}
 	certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, net.ParseIP("127.0.0.1"))
-
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: mmerrill3 <michael.merrill@vonage.com>

- Wrapping new etcd client healthcheck and member listings around an explicit timeout #371 
- localhost loopback IP only needs to be in IP list of SAN certificate once