### PR TITLE
Handling hanging list command from etcd client during reconciliation loop

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -691,7 +691,12 @@ func (m *EtcdController) updateClusterState(ctx context.Context, peers []*peer) 
 			klog.Warningf("unable to reach member %s: %v", p, err)
 			continue
 		}
-		members, err := etcdClient.ListMembers(ctx)
+
+		klog.V(2).Infof("base client OK for etcd for client urls %s", clientUrls)
+		etcdClientCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		members, err := etcdClient.ListMembers(etcdClientCtx)
+		cancel()
+
 		etcdclient.LoggedClose(etcdClient)
 		if err != nil {
 			klog.Warningf("unable to reach member for ListMembers %s: %v", p, err)

--- a/pkg/etcd/pki.go
+++ b/pkg/etcd/pki.go
@@ -147,7 +147,12 @@ func addAltNames(certConfig *certutil.Config, urls []string) error {
 	}
 
 	// We always self-sign for 127.0.0.1, so that we can always be reached by apiserver / debug clients
+	// sometimes it will be there already
+	for _, ip := range certConfig.AltNames.IPs {
+		if ip.String() == "127.0.0.1" {
+			return nil
+		}
+	}
 	certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, net.ParseIP("127.0.0.1"))
-
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: mmerrill3 <michael.merrill@vonage.com>

- Wrapping new etcd client member listings around an explicit timeout #371 
- localhost loopback IP only needs to be in IP list of SAN certificate once