### PR TITLE
Include IPs in peer certificates

### DIFF
--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -19,6 +19,7 @@ package etcd
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -63,6 +64,10 @@ type EtcdServer struct {
 
 	// listenMetricsURLs is the set of URLs where etcd should listen for metrics
 	listenMetricsURLs []string
+
+	// peerClientIPs is the set of IPs from which we connect to peers, used for the deeper cert validation in etcd 3.2
+	// (see https://github.com/kopeio/etcd-manager/issues/371)
+	peerClientIPs []net.IP
 }
 
 type preparedState struct {
@@ -70,7 +75,7 @@ type preparedState struct {
 	clusterToken string
 }
 
-func NewEtcdServer(baseDir string, clusterName string, listenAddress string, listenMetricsURLs []string, etcdNodeConfiguration *protoetcd.EtcdNode, peerServer *privateapi.Server, dnsProvider dns.Provider, etcdClientsCA *pki.Keypair, etcdPeersCA *pki.Keypair) (*EtcdServer, error) {
+func NewEtcdServer(baseDir string, clusterName string, listenAddress string, listenMetricsURLs []string, etcdNodeConfiguration *protoetcd.EtcdNode, peerServer *privateapi.Server, dnsProvider dns.Provider, etcdClientsCA *pki.Keypair, etcdPeersCA *pki.Keypair, peerClientIPs []net.IP) (*EtcdServer, error) {
 	s := &EtcdServer{
 		baseDir:               baseDir,
 		clusterName:           clusterName,
@@ -81,6 +86,7 @@ func NewEtcdServer(baseDir string, clusterName string, listenAddress string, lis
 		etcdClientsCA:         etcdClientsCA,
 		etcdPeersCA:           etcdPeersCA,
 		listenMetricsURLs:     listenMetricsURLs,
+		peerClientIPs:         peerClientIPs,
 	}
 
 	// Make sure we have read state from disk before serving
@@ -593,7 +599,7 @@ func (s *EtcdServer) startEtcdProcess(state *protoetcd.EtcdState) error {
 	}
 
 	// We always generate the keypairs, as this allows us to switch to TLS without a restart
-	if err := p.createKeypairs(s.etcdPeersCA, s.etcdClientsCA, pkiDir, meNode); err != nil {
+	if err := p.createKeypairs(s.etcdPeersCA, s.etcdClientsCA, pkiDir, meNode, s.peerClientIPs); err != nil {
 		return err
 	}
 

--- a/pkg/etcd/pki.go
+++ b/pkg/etcd/pki.go
@@ -29,7 +29,7 @@ import (
 	"kope.io/etcd-manager/pkg/pki"
 )
 
-func (p *etcdProcess) createKeypairs(peersCA *pki.Keypair, clientsCA *pki.Keypair, pkiDir string, me *protoetcd.EtcdNode) error {
+func (p *etcdProcess) createKeypairs(peersCA *pki.Keypair, clientsCA *pki.Keypair, pkiDir string, me *protoetcd.EtcdNode, peerClientIPs []net.IP) error {
 	if peersCA != nil {
 		peersDir := filepath.Join(pkiDir, "peers")
 		p.PKIPeersDir = peersDir
@@ -51,9 +51,18 @@ func (p *etcdProcess) createKeypairs(peersCA *pki.Keypair, clientsCA *pki.Keypai
 			Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		}
 
+		// etcd 3.2 does some deeper client-certiifcate validation, so we want to include our client IP address
+		// (as the DNS name might not be immediately ready, see https://github.com/kopeio/etcd-manager/issues/371)
+		for _, ip := range peerClientIPs {
+			certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, ip)
+		}
+		klog.Infof("adding peerClientIPs %v", peerClientIPs)
+
 		if err := addAltNames(&certConfig, me.PeerUrls); err != nil {
 			return err
 		}
+
+		certConfig.AltNames.IPs = removeDuplicateIPs(certConfig.AltNames.IPs)
 
 		klog.Infof("generating peer keypair for etcd: %+v", certConfig)
 
@@ -155,4 +164,18 @@ func addAltNames(certConfig *certutil.Config, urls []string) error {
 	}
 	certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, net.ParseIP("127.0.0.1"))
 	return nil
+}
+
+func removeDuplicateIPs(ips []net.IP) []net.IP {
+	m := make(map[string]bool)
+	var out []net.IP
+	for _, ip := range ips {
+		s := ip.String()
+		if m[s] {
+			continue
+		}
+		m[s] = true
+		out = append(out, ip)
+	}
+	return out
 }

--- a/pkg/etcd/restore.go
+++ b/pkg/etcd/restore.go
@@ -19,6 +19,7 @@ package etcd
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -191,7 +192,9 @@ func RunEtcdFromBackup(backupStore backup.Store, backupName string, basedir stri
 		etcdPeersCA = ca
 	}
 
-	if err := p.createKeypairs(etcdPeersCA, etcdClientsCA, pkiDir, myNode); err != nil {
+	var peerClientIPs []net.IP // We restore using a single localhost server, so no additional cert SANs needed
+
+	if err := p.createKeypairs(etcdPeersCA, etcdClientsCA, pkiDir, myNode, peerClientIPs); err != nil {
 		return nil, err
 	}
 

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -212,7 +212,8 @@ func (n *TestHarnessNode) Run() {
 		etcdPeersCA = nil
 	}
 
-	etcdServer, err := etcd.NewEtcdServer(n.NodeDir, n.TestHarness.ClusterName, n.Address, n.ListenMetricsURLs, me, peerServer, dnsProvider, etcdClientsCA, etcdPeersCA)
+	var peerClientIPs []net.IP
+	etcdServer, err := etcd.NewEtcdServer(n.NodeDir, n.TestHarness.ClusterName, n.Address, n.ListenMetricsURLs, me, peerServer, dnsProvider, etcdClientsCA, etcdPeersCA, peerClientIPs)
 	if err != nil {
 		t.Fatalf("error building EtcdServer: %v", err)
 	}


### PR DESCRIPTION
This addresses the deeper client-certificate validation introduced in
etcd 3.2, without relying on DNS.