### PR TITLE
Use etcd v3.4.13 in tests

### DIFF
--- a/test/integration/clusterformation_test.go
+++ b/test/integration/clusterformation_test.go
@@ -77,7 +77,7 @@ func TestClusterWithThreeMembers(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -107,7 +107,7 @@ func TestClusterExpansion(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -159,7 +159,7 @@ func TestWeOnlyFormASingleCluster(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "3.4.13"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")

--- a/test/integration/datapersists_test.go
+++ b/test/integration/datapersists_test.go
@@ -34,7 +34,7 @@ func TestClusterDataPersists(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "3.4.13"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -92,7 +92,7 @@ func TestHAReadWrite(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -160,7 +160,7 @@ func TestHARecovery(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "2.2.1"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")

--- a/test/integration/harness/cluster.go
+++ b/test/integration/harness/cluster.go
@@ -156,7 +156,7 @@ func (h *TestHarness) NewNode(address string) *TestHarnessNode {
 		TestHarness: h,
 		Address:     address,
 		NodeDir:     nodeDir,
-		EtcdVersion: "2.2.1",
+		EtcdVersion: "3.4.13",
 	}
 	if err := n.Init(); err != nil {
 		t.Fatalf("error initializing node: %v", err)


### PR DESCRIPTION
May be a good idea to move to a newer version of etcd in tests, where possible.