### PR TITLE
Eager-broadcast leadership on every leader iteration

### DIFF
--- a/pkg/privateapi/leadership.go
+++ b/pkg/privateapi/leadership.go
@@ -194,6 +194,46 @@ func (s *Server) BecomeLeader(ctx context.Context) ([]PeerId, string, error) {
 	return acked, request.View.LeadershipToken, nil
 }
 
+func (s *Server) AssertLeadership(ctx context.Context, leadershipToken string) error {
+	// TODO: Should we send a notification if we ourselves would reject it?
+	snapshot, infos := s.snapshotHealthy()
+
+	request := &LeaderNotificationRequest{}
+
+	request.View = &View{}
+	for _, info := range infos {
+		request.View.Healthy = append(request.View.Healthy, info)
+	}
+	request.View.Leader = &s.myInfo
+	request.View.LeadershipToken = leadershipToken
+
+	for peerID := range snapshot {
+		conn, err := s.GetPeerClient(peerID)
+		if err != nil {
+			return fmt.Errorf("error getting peer client for %q: %w", peerID, err)
+		}
+
+		peerClient := NewClusterServiceClient(conn)
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		response, err := peerClient.LeaderNotification(timeoutCtx, request)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("error sending leader assertion to %q: %w", peerID, err)
+		}
+
+		if response.View != nil {
+			s.addPeersFromView(response.View)
+		}
+
+		if !response.Accepted {
+			return fmt.Errorf("our leadership assertion was not accepted by peer %q: %v", peerID, response)
+		}
+	}
+
+	return nil
+}
+
 func randomToken() string {
 	b := make([]byte, 16, 16)
 	_, err := io.ReadFull(crypto_rand.Reader, b)

--- a/pkg/privateapi/peers.go
+++ b/pkg/privateapi/peers.go
@@ -46,6 +46,7 @@ type Peers interface {
 	MyPeerId() PeerId
 	GetPeerClient(peerId PeerId) (*grpc.ClientConn, error)
 	BecomeLeader(ctx context.Context) ([]PeerId, string, error)
+	AssertLeadership(ctx context.Context, leadershipToken string) error
 	IsLeader(token string) bool
 }
 


### PR DESCRIPTION
Previously we assumed that if our peers didn't change and we had the
leadership, that the peers would continue to acknowledge our
leadership.  But this assumes that a peer didn't restart or crash.
Instead, on every leader iteration, check with all the peers that we
are still the leader (using the same GRPC method).  For negligible
additional traffic, this should enable greater recovery from errors
and greater consistency of leader election.

Issue #348