### PR TITLE
Add log levels to prevent too verbose logging

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -263,7 +263,7 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 	}
 
 	{
-		klog.Infof("Broadcasting leadership assertion with token %q", m.leadership.token)
+		klog.V(3).Infof("Broadcasting leadership assertion with token %q", m.leadership.token)
 		// We always broadcast our leadership claim, to ensure that all peers are in sync
 		err := m.peers.AssertLeadership(ctx, m.leadership.token)
 		if err != nil {
@@ -282,7 +282,7 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 	{
 		for _, peer := range peers {
 			if !m.leadership.ackedPeers[peer.Id] {
-				klog.Infof("peer %q has not acked our leadership; resigning leadership", peer)
+				klog.V(3).Infof("peer %q has not acked our leadership; resigning leadership", peer)
 				m.leadership = nil
 
 				// Wait one cycle after leadership changes
@@ -292,14 +292,14 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 		}
 	}
 
-	klog.Infof("I am leader with token %q", m.leadership.token)
+	klog.V(3).Infof("I am leader with token %q", m.leadership.token)
 
 	// Query all our peers to try to find the actual state of etcd on each node
 	clusterState, err := m.updateClusterState(ctx, peers)
 	if err != nil {
 		return false, fmt.Errorf("error building cluster state: %v", err)
 	}
-	klog.Infof("etcd cluster state: %s", clusterState)
+	klog.V(3).Infof("etcd cluster state: %s", clusterState)
 	klog.V(2).Infof("etcd cluster members: %s", clusterState.members)
 
 	now := time.Now()
@@ -392,7 +392,7 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 		klog.Infof("no cluster spec set - must seed new cluster")
 		return false, nil
 	}
-	klog.Infof("spec %v", clusterSpec)
+	klog.V(3).Infof("spec %v", clusterSpec)
 
 	desiredQuorumSize := quorumSize(int(clusterSpec.MemberCount))
 
@@ -554,7 +554,7 @@ func (m *EtcdController) run(ctx context.Context) (bool, error) {
 		}
 	}
 
-	klog.Infof("controller loop complete")
+	klog.V(3).Infof("controller loop complete")
 
 	return false, nil
 }
@@ -638,7 +638,7 @@ func (m *EtcdController) buildMemberMap(etcdClusterState *etcdClusterState) *pro
 
 func (m *EtcdController) broadcastMemberMap(ctx context.Context, etcdClusterState *etcdClusterState, memberMap *protoetcd.MemberMap) []error {
 	// TODO: optimize this
-	klog.Infof("sending member map to all peers: %v", memberMap)
+	klog.V(3).Infof("sending member map to all peers: %v", memberMap)
 
 	var errors []error
 	for _, peer := range etcdClusterState.peers {

--- a/pkg/etcd/etcdserver.go
+++ b/pkg/etcd/etcdserver.go
@@ -245,7 +245,7 @@ func (s *EtcdServer) UpdateEndpoints(ctx context.Context, request *protoetcd.Upd
 		}
 
 		if len(addressToHosts) != 0 {
-			klog.Infof("updating hosts: %v", addressToHosts)
+			klog.V(3).Infof("updating hosts: %v", addressToHosts)
 			if err := s.dnsProvider.UpdateHosts(addressToHosts); err != nil {
 				klog.Warningf("error updating hosts: %v", err)
 				return nil, err

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -81,7 +81,7 @@ func (h *Provider) update() error {
 		}
 	}
 
-	klog.Infof("hosts update: primary=%v, fallbacks=%v, final=%v", h.primary, h.fallbacks, addrToHosts)
+	klog.V(3).Infof("hosts update: primary=%v, fallbacks=%v, final=%v", h.primary, h.fallbacks, addrToHosts)
 	return updateHostsFileWithRecords("/etc/hosts", h.Key, addrToHosts)
 }
 

--- a/pkg/privateapi/leadership.go
+++ b/pkg/privateapi/leadership.go
@@ -34,7 +34,7 @@ type leadership struct {
 }
 
 func (s *Server) LeaderNotification(ctx grpccontext.Context, request *LeaderNotificationRequest) (*LeaderNotificationResponse, error) {
-	klog.Infof("Got LeaderNotification %s", request)
+	klog.V(3).Infof("Got LeaderNotification %s", request)
 
 	if request.View == nil {
 		return nil, fmt.Errorf("View is required")


### PR DESCRIPTION
This PR would change Etcd-manager to use klog.V(3).Infof instead of plain klog.Infof for frequently occuring informational events.

We have been looking into logs generated by etcd-manager. Running an idle cluster with three master nodes, i.e. two etcd-manager clusters and six members with -v=1 results in about 300 000 log events in 24h, without significant deviations after running for few days.

After these changes, the number of log events is somewhere around 2000 events per day, which mostly include information about backup and compaction events.