### PR TITLE
Make discovery poll interval configurable

### DIFF
--- a/cmd/etcd-manager/main.go
+++ b/cmd/etcd-manager/main.go
@@ -81,6 +81,7 @@ func main() {
 	flag.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "name of cluster")
 	flag.StringVar(&o.BackupStorePath, "backup-store", o.BackupStorePath, "backup store location")
 	flag.StringVar(&o.BackupInterval, "backup-interval", o.BackupInterval, "interval for periodic backups")
+	flag.StringVar(&o.DiscoveryPollInterval, "discovery-poll-interval", o.DiscoveryPollInterval, "interval for discovery poll")
 	flag.StringVar(&o.DataDir, "data-dir", o.DataDir, "directory for storing etcd data")
 
 	flag.StringVar(&o.PKIDir, "pki-dir", o.PKIDir, "directory for PKI keys")
@@ -123,20 +124,21 @@ func expandUrls(urls string, address string, name string) []string {
 
 // EtcdManagerOptions holds the flag options for running etcd-manager
 type EtcdManagerOptions struct {
-	PKIDir               string
-	Address              string
-	VolumeProviderID     string
-	PeerUrls             string
-	GrpcPort             int
-	ClientUrls           string
-	QuarantineClientUrls string
-	ClusterName          string
-	ListenAddress        string
-	BackupStorePath      string
-	DataDir              string
-	VolumeTags           []string
-	NameTag              string
-	BackupInterval       string
+	PKIDir                string
+	Address               string
+	VolumeProviderID      string
+	PeerUrls              string
+	GrpcPort              int
+	ClientUrls            string
+	QuarantineClientUrls  string
+	ClusterName           string
+	ListenAddress         string
+	BackupStorePath       string
+	DataDir               string
+	VolumeTags            []string
+	NameTag               string
+	BackupInterval        string
+	DiscoveryPollInterval string
 
 	// DNSSuffix is added to etcd member names and we then use internal client id discovery
 	DNSSuffix string
@@ -160,6 +162,7 @@ func (o *EtcdManagerOptions) InitDefaults() {
 	//o.Address = "127.0.0.1"
 
 	o.BackupInterval = "15m"
+	o.DiscoveryPollInterval = "60s"
 
 	o.ClientUrls = "https://__address__:4001"
 	o.QuarantineClientUrls = "https://__address__:8001"
@@ -406,7 +409,11 @@ func RunEtcdManager(o *EtcdManagerOptions) error {
 		Id:        string(myPeerId),
 		Endpoints: []string{grpcEndpoint},
 	}
-	peerServer, err := privateapi.NewServer(ctx, myInfo, grpcServerTLS, discoveryProvider, o.GrpcPort, dnsProvider, o.DNSSuffix, grpcClientTLS)
+	discoveryPollInterval, err := time.ParseDuration(o.DiscoveryPollInterval)
+	if err != nil {
+		return fmt.Errorf("invalid discovery-poll-interval duration %q", o.DiscoveryPollInterval)
+	}
+	peerServer, err := privateapi.NewServer(ctx, myInfo, grpcServerTLS, discoveryProvider, o.GrpcPort, dnsProvider, o.DNSSuffix, grpcClientTLS, discoveryPollInterval)
 	if err != nil {
 		return fmt.Errorf("error building server: %v", err)
 	}

--- a/pkg/privateapi/peers.go
+++ b/pkg/privateapi/peers.go
@@ -36,9 +36,6 @@ import (
 const defaultPingInterval = time.Second * 5
 const defaultHealthyTimeout = time.Minute
 
-// defaultDiscoveryPollInterval is the default value of Server::DiscoveryPollInterval
-const defaultDiscoveryPollInterval = time.Minute
-
 type PeerId string
 
 type Peers interface {

--- a/pkg/privateapi/server.go
+++ b/pkg/privateapi/server.go
@@ -66,7 +66,7 @@ type Server struct {
 	dnsSuffix string
 }
 
-func NewServer(ctx context.Context, myInfo PeerInfo, serverTLSConfig *tls.Config, discovery discovery.Interface, defaultPort int, dnsProvider dns.Provider, dnsSuffix string, clientTLSConfig *tls.Config) (*Server, error) {
+func NewServer(ctx context.Context, myInfo PeerInfo, serverTLSConfig *tls.Config, discovery discovery.Interface, defaultPort int, dnsProvider dns.Provider, dnsSuffix string, clientTLSConfig *tls.Config, discoveryPollInterval time.Duration) (*Server, error) {
 	s := &Server{
 		context:         ctx,
 		discovery:       discovery,
@@ -77,7 +77,7 @@ func NewServer(ctx context.Context, myInfo PeerInfo, serverTLSConfig *tls.Config
 		dnsProvider:     dnsProvider,
 		dnsSuffix:       dnsSuffix,
 
-		DiscoveryPollInterval: defaultDiscoveryPollInterval,
+		DiscoveryPollInterval: discoveryPollInterval,
 		PingInterval:          defaultPingInterval,
 		HealthyTimeout:        defaultHealthyTimeout,
 	}

--- a/test/integration/harness/node.go
+++ b/test/integration/harness/node.go
@@ -156,7 +156,8 @@ func (n *TestHarnessNode) Run() {
 		Id:        string(uniqueID),
 		Endpoints: []string{grpcEndpoint},
 	}
-	peerServer, err := privateapi.NewServer(n.ctx, myInfo, serverTLSConfig, disco, grpcPort, dnsProvider, dnsSuffix, clientTLSConfig)
+	discoveryInterval := time.Second * 5
+	peerServer, err := privateapi.NewServer(n.ctx, myInfo, serverTLSConfig, disco, grpcPort, dnsProvider, dnsSuffix, clientTLSConfig, discoveryInterval)
 	peerServer.PingInterval = time.Second
 	peerServer.HealthyTimeout = time.Second * 5
 	peerServer.DiscoveryPollInterval = time.Second * 5


### PR DESCRIPTION
current solution is that it will query discovery `Poll` each minute. However, when we have for instance kops cluster it means that we have 6 etcd manager processes. This means that etcd-manager will query each 10 seconds the status from the cloudprovider API. This means total 8640 queries/day and in case of for instance OpenStack / GCP it makes also 8640 * 3 ~ 26k compute API calls /day. In my opinion this is too much and that is why I would like to configure this value.

It is not problem if we have one cluster in whole cloud, but if we have for instance 100 kops clusters those numbers are pretty high.
