### PR TITLE
scripts: Find bazel output in the new locations

### DIFF
--- a/dev/build-assets.sh
+++ b/dev/build-assets.sh
@@ -33,12 +33,14 @@ for CMD in ${CMDS}; do
         fi
 
         # Build
-        bazel build --platforms=@io_bazel_rules_go//go/toolchain:${PLATFORM} //cmd/${CMD}
+        bazel build --@io_bazel_rules_go//go/config:pure --platforms=@io_bazel_rules_go//go/toolchain:${PLATFORM} //cmd/${CMD}
 
         if [ -e "bazel-bin/cmd/${CMD}/${PLATFORM}_stripped/${CMD}${EXTENSION}" ]; then
             cp bazel-bin/cmd/${CMD}/${PLATFORM}_stripped/${CMD}${EXTENSION} ${CMD_DIST_PATH}
         elif [ -e "bazel-bin/cmd/${CMD}/${PLATFORM}_pure_stripped/${CMD}${EXTENSION}" ]; then
             cp bazel-bin/cmd/${CMD}/${PLATFORM}_pure_stripped/${CMD}${EXTENSION} ${CMD_DIST_PATH}
+        elif [ -e "bazel-bin/cmd/${CMD}/${CMD}_/${CMD}${EXTENSION}" ]; then
+            cp bazel-bin/cmd/${CMD}/${CMD}_/${CMD}${EXTENSION} ${CMD_DIST_PATH}
         else
             echo "Unable to find compiled binary for ${CMD} ${PLATFORM}"
             exit 1


### PR DESCRIPTION
The output paths of bazel binaries has moved.  kOps has a different
workaround, where the output paths are selected based on platform; we
could look at that instead in future.